### PR TITLE
feat(ci): add job for check, clippy and fmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Build & Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: clippy,rustfmt
+      - run: just check

--- a/justfile
+++ b/justfile
@@ -6,8 +6,8 @@ fmt:
 
 check:
   cargo +nightly fmt -- --check
-  cargo clippy -- -D warnings
-  cargo check --all-features
+  cargo +nightly clippy -- -D warnings
+  cargo +nightly check --all-features
 
 example name="example":
   cargo run --example {{name}} --release


### PR DESCRIPTION
Closes #6.

Add a CI job for `check`, `clippy` and `fmt` on the nightly toolchain.