### PR TITLE
chore(deps): bump Floresta and remove `rustreexo`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,8 @@ rust-version = "1.74.1"
 
 [dependencies]
 bdk_wallet = "2.2.0"
-floresta-chain = { git = "https://github.com/vinteumorg/Floresta.git", rev = "d79e135f40515a859850dd59a6ee057f11c69128", features = ["flat-chainstore"] } # Tracing PR
-floresta-wire = { git = "https://github.com/vinteumorg/Floresta.git", rev = "d79e135f40515a859850dd59a6ee057f11c69128" }                                  # Tracing PR
-rustreexo = "0.4.0"
+floresta-chain = { git = "https://github.com/vinteumorg/Floresta.git", rev = "7fedb3a94abcd524f1eb809f4eb80b70bae3e89f", features = ["flat-chainstore"] }
+floresta-wire = { git = "https://github.com/vinteumorg/Floresta.git", rev = "7fedb3a94abcd524f1eb809f4eb80b70bae3e89f" }
 thiserror = "2.0.17"
 tokio = { version = "1.47.1", features = ["full"] }
 tracing = "0.1.41"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -12,11 +12,14 @@ use floresta_chain::{
     AssumeUtreexoValue, AssumeValidArg, ChainParams, ChainState,
 };
 use floresta_wire::{
-    address_man::AddressMan, mempool::Mempool, node::UtreexoNode,
-    node_interface::NodeInterface, running_node::RunningNode,
+    address_man::AddressMan,
+    mempool::Mempool,
+    node::UtreexoNode,
+    node_interface::NodeInterface,
+    running_node::RunningNode,
+    rustreexo::accumulator::{node_hash::BitcoinNodeHash, pollard::Pollard},
     UtreexoNodeConfig,
 };
-use rustreexo::accumulator::{node_hash::BitcoinNodeHash, pollard::Pollard};
 use tokio::{
     sync::{oneshot, Mutex, RwLock},
     task,
@@ -69,7 +72,7 @@ impl Default for FlorestaBuilder {
         // The default behaviour for the backfill job. Default to `false`.
         let backfill_default: bool = false;
 
-        // The default user agent for P2P communications.
+        // The default user agent for P2P communication.
         let user_agent_default = env!("USER_AGENT").to_string();
 
         Self {


### PR DESCRIPTION
Since [Floresta#669](https://github.com/vinteumorg/Floresta/pull/669), `rustreexo` is re-exported by `floresta-wire`. We don't need to import here anymore.