### PR TITLE
fix(lib): abort `sigint_task` on `wait_shutdown()` instead of waiting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,15 +119,17 @@ impl FlorestaNode {
         let _ = self.flush();
 
         if let Some(sigint) = self.sigint_task.take() {
-            let _ = sigint.await;
+            sigint.abort();
         }
 
         info!("Shutdown complete");
         Ok(())
     }
 
-    /// Convenience method: signal that the node
-    /// should stop and then wait for tasks to complete.
+    /// Signal that [`FlorestaNode`] should stop,
+    /// and then wait for it's tasks to complete.
+    ///
+    /// This is a convenience method that bundles `stop()` and `wait_shutdown`.
     pub async fn shutdown(self) -> Result<(), NodeError> {
         self.stop().await;
         self.wait_shutdown().await


### PR DESCRIPTION
Previously, shutting down the node via `FlorestaNode::wait_shutdown()` would wait indefinitely, since no SIGINT was sent. This commit aborts the `sigint_task` instead of waiting for a SIGINT that would never arrive.