### PR TITLE
feat(lib): add `FlorestaNode::get_block()` and `FlorestaNode::get_blockhash()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,6 +329,13 @@ impl FlorestaNode {
         Ok(stump)
     }
 
+    /// Get a [`BlockHash`] from a block height.
+    pub fn get_blockhash(&self, height: u32) -> Result<BlockHash, NodeError> {
+        let hash = self.chain_state.get_block_hash(height)?;
+
+        Ok(hash)
+    }
+
     /// Get a [`Block`], given it's [`BlockHash`], from the network.
     pub async fn get_block(
         &self,


### PR DESCRIPTION
Adds a couple methods that allow fetching `Block`s from the P2P network and getting a `BlockHash` from an `u32` height.