### PR TITLE
Refactor `Logger` and Update CI workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,18 @@
 version: 2
+
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-      time: "00:00"
-    cooldown:
-      default-days: 14
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-      time: "00:00"
-    cooldown:
-      default-days: 14
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "monthly"
+          time: "00:00"
+      cooldown:
+          default-days: 14
+
+    - package-ecosystem: "cargo"
+      directory: "/"
+      schedule:
+          interval: "monthly"
+          time: "00:00"
+      cooldown:
+          default-days: 14

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,37 +1,32 @@
 name: Security Audit
-on: [push, pull_request]
-permissions: {}
+
+on:
+    push:
+    pull_request:
 env:
-  CARGO_TERM_COLOR: always
+    CARGO_TERM_COLOR: always
+permissions: {}
 
 jobs:
-  supply-chain:
-    name: 'cargo-audit'
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    timeout-minutes: 30
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
+    audit:
+        name: cargo-audit
+        runs-on: ubuntu-latest
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+        permissions:
+            contents: read
 
-      - name: Install Rust toolchain
-        run: |
-            rustup toolchain install nightly --profile minimal
-            rustup default nightly
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
 
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          cache-on-failure: true
+            - name: Install cargo-audit
+              run: cargo install cargo-audit --locked
 
-      - name: Install cargo-audit
-        run: cargo install cargo-audit@0.22.1 --force --locked
+            - name: Check for audit warnings
+              run: cargo audit -D warnings
+              continue-on-error: true
 
-      - name: Check for Audit Warnings
-        run: cargo audit -D warnings
-        continue-on-error: true
-
-      - name: Check for Vulnerabilities
-        run: cargo audit
+            - name: Check for vulnerabilities
+              run: cargo audit

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,53 +1,59 @@
 name: Rust CI
+
 on: [push, pull_request]
+
 permissions: {}
 env:
-  CARGO_TERM_COLOR: always
+    CARGO_TERM_COLOR: always
+    RUST_BACKTRACE: 1
 
 jobs:
-  Test:
-    name: Test - ${{ matrix.toolchain }} toolchain, ${{ matrix.dep }} deps
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain: [stable, msrv]
-        dep: [minimal, recent]
-        exclude:
-          # Exclude MSRV toolchain + `Cargo-recent.lock`
-          - toolchain: msrv
-            dep: recent
+    check:
+        name: Check - ${{ matrix.task }}
+        runs-on: ubuntu-latest
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+        strategy:
+            fail-fast: false
+            matrix:
+                task: [fmt --check, lint, docs]
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
+            - name: Setup build cache
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      - name: Setup cargo-rbmt
-        uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/setup-rbmt@6560b728ae6a81af9d92713b630ba26772fbd970
+            - name: Setup cargo-rbmt
+              uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/setup-rbmt@6560b728ae6a81af9d92713b630ba26772fbd970
 
-      - name: Run tests
-        run: cargo rbmt test --toolchain ${{ matrix.toolchain }} --lock-file ${{ matrix.dep }}
+            - name: Run ${{ matrix.task }}
+              run: cargo rbmt ${{ matrix.task }}
 
-  Check:
-    name: Check - ${{ matrix.task }}
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    strategy:
-      fail-fast: false
-      matrix:
-        task: [lint, docs]
+    test:
+        name: Test - ${{ matrix.toolchain }} toolchain, ${{ matrix.lockfile }} deps
+        runs-on: ubuntu-latest
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+        strategy:
+            fail-fast: false
+            matrix:
+                toolchain: [stable, nightly, msrv]
+                lockfile: [minimal, recent]
+                exclude:
+                    - toolchain: msrv
+                      lockfile: recent
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
+            - name: Setup build cache
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      - name: Setup cargo-rbmt
-        uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/setup-rbmt@6560b728ae6a81af9d92713b630ba26772fbd970
+            - name: Setup cargo-rbmt
+              uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/setup-rbmt@6560b728ae6a81af9d92713b630ba26772fbd970
 
-      - name: Run ${{ matrix.task }}
-        run: cargo rbmt ${{ matrix.task }}
+            - name: Run tests
+              run: cargo rbmt test --toolchain ${{ matrix.toolchain }} --lock-file ${{ matrix.lockfile }}

--- a/.github/workflows/sigs.yml
+++ b/.github/workflows/sigs.yml
@@ -1,23 +1,26 @@
 name: Signed Commits
+
 on: [push, pull_request]
+
 permissions: {}
 env:
-  CARGO_TERM_COLOR: always
+    CARGO_TERM_COLOR: always
 
 jobs:
-  Signatures:
-    name: Assert all commits are signed
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          fetch-depth: 0
+    commit-signatures:
+        name: Assert all commits are PGP-signed
+        runs-on: ubuntu-latest
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
-      - name: Setup just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+                  fetch-depth: 0
 
-      - name: Check commit signatures
-        run: just check-sigs
+            - name: Setup just
+              uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
+
+            - name: Check commit signatures
+              run: bash contrib/check-signatures.sh

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,22 +1,27 @@
 name: Zizmor
-on: [push, pull_request]
+on:
+    push:
+    pull_request:
+    schedule:
+        - cron: "0 12 * * 1" # Monday, 12:00:00 UTC
+    workflow_dispatch:
+
 permissions: {}
-env:
-  CARGO_TERM_COLOR: always
 
 jobs:
-  zizmor:
-    name: Zizmor Static Analysis
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
+    zizmor:
+        name: Action Static Analysis
+        runs-on: ubuntu-latest
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
 
-      - name: Run Zizmor
-        run: uvx zizmor .
+            - name: Install uv
+              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+            - name: Run zizmor
+              run: uvx zizmor .

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <!-- <a href="https://docs.rs/bdk_floresta"><img src="https://img.shields.io/badge/docs.rs-bdk--floresta-brightgreen"/></a> -->
     <a href="https://blog.rust-lang.org/2025/02/20/Rust-1.85.0/"><img src="https://img.shields.io/badge/rustc-1.85.0%2B-orange.svg"/></a>
     <a href="https://github.com/luisschwab/bdk-floresta/blob/master/LICENSE"><img src="https://img.shields.io/badge/License-MIT%2FApache--2.0-red.svg"/></a>
-    <a href="https://github.com/luisschwab/bdk-floresta/actions/workflows/ci.yml"><img src="https://github.com/luisschwab/bdk-floresta/actions/workflows/ci.yml/badge.svg"></a>
+    <a href="https://github.com/luisschwab/bdk-floresta/actions/workflows/rust.yml"><img src="https://github.com/luisschwab/bdk-floresta/actions/workflows/rust.yml/badge.svg"></a>
 </p>
 
 A Floresta-powered chain-source crate for BDK.

--- a/contrib/check-signatures.sh
+++ b/contrib/check-signatures.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# This script will check if all commits in this branch are PGP-signed.
+
+set -euo pipefail
+
+BASE=${1:-origin/master}
+RANGE="$BASE..HEAD"
+
+TOTAL=$(git log --pretty='tformat:%H' "$RANGE" | wc -l | tr -d ' ')
+UNSIGNED=$(git log --pretty='tformat:%H %G?' "$RANGE" | awk '$2 == "N" {count++} END {print count+0}')
+
+if [ "$UNSIGNED" -gt 0 ]; then
+    echo "⚠️ Unsigned commits in this branch [$UNSIGNED/$TOTAL]"
+    exit 1
+else
+    echo "🔏 All commits in this branch are signed [$TOTAL/$TOTAL]"
+fi

--- a/justfile
+++ b/justfile
@@ -14,6 +14,7 @@ build:
 
 # Check code formatting, compilation, linting, and commit signature
 check:
+    cargo rbmt fmt --check
     cargo rbmt lint
     cargo rbmt docs
     just check-sigs
@@ -24,15 +25,7 @@ check-features:
 
 # Checks whether all commits in this branch are signed
 check-sigs:
-    #!/usr/bin/env bash
-    TOTAL=$(git log --pretty='tformat:%H' origin/master..HEAD | wc -l | tr -d ' ')
-    UNSIGNED=$(git log --pretty='tformat:%H %G?' origin/master..HEAD | grep " N$" | wc -l | tr -d ' ')
-    if [ "$UNSIGNED" -gt 0 ]; then
-        echo "⚠️ Unsigned commits in this branch [$UNSIGNED/$TOTAL]"
-        exit 1
-    else
-        echo "🔏 All commits in this branch are signed [$TOTAL/$TOTAL]"
-    fi
+    bash contrib/check-signatures.sh
 
 # Delete files: data, target, lockfiles
 delete item="data":
@@ -48,8 +41,9 @@ doc-open: doc
     cargo rbmt docs
     cargo doc --no-deps --open
 
-# Run an example crate
-example name="node":
+# Run an example: `regtest_ibd`, `signet_ibd`
+example name="regtest_ibd":
+    rm -rf examples/data/regtest_ibd
     cargo run --release --example {{ name }}
 
 # Format code

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -39,11 +39,7 @@ use tracing::info;
 
 use crate::error::BuilderError;
 #[cfg(feature = "logger")]
-use crate::logger::start_logger;
-#[cfg(feature = "logger")]
-use crate::logger::LoggerConfig;
-#[cfg(feature = "logger")]
-use crate::logger::LOG_FILE;
+use crate::logger::Logger;
 use crate::updater::WalletUpdater;
 use crate::Node;
 use crate::WalletUpdate;
@@ -155,7 +151,7 @@ pub struct Builder {
     pub node_configuration: NodeConfig,
     /// Configuration for building the tracing subscriber logger.
     #[cfg(feature = "logger")]
-    pub logger_configuration: LoggerConfig,
+    pub logger: Option<Logger>,
     /// A [`Wallet`] that will receive updates from the [`Node`].
     pub wallet: Option<Wallet>,
 }
@@ -169,6 +165,12 @@ impl Builder {
     /// Instantiate a [`Builder`] from a [`NodeConfig`].
     pub fn from_config(mut self, node_configuration: NodeConfig) -> Self {
         self.node_configuration = node_configuration;
+        self
+    }
+
+    #[cfg(feature = "logger")]
+    pub fn with_logger(mut self, logger: Logger) -> Self {
+        self.logger = Some(logger);
         self
     }
 
@@ -192,15 +194,13 @@ impl Builder {
         // Create the data directory for node and wallet data.
         fs::create_dir_all(&self.node_configuration.data_directory)?;
 
-        // Keep a guard for the logger during the node's lifetime.
+        // Init the logger, and keep a guard if logging to a file is enabled.
         #[cfg(feature = "logger")]
-        let _logger_guard = start_logger(
-            &self.node_configuration.data_directory,
-            Some(LOG_FILE.to_string()),
-            self.logger_configuration.log_to_file,
-            self.logger_configuration.log_to_stdout,
-            self.logger_configuration.log_level,
-        )?;
+        let _log_guard = if let Some(logger) = self.logger {
+            logger.init()?
+        } else {
+            None
+        };
 
         // Configure the [`FlatChainStore`].
         let chain_store_cfg = FlatChainStoreConfig::new(
@@ -293,7 +293,7 @@ impl Builder {
             wallet: wallet_arc,
             update_subscriber: Some(update_rx),
             #[cfg(feature = "logger")]
-            _logger_guard,
+            _log_guard,
         })
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use thiserror::Error;
 
 /// Errors which might occur when building the
-/// [`Node`](crate::node::Node) or [logger](crate::logger::start_logger).
+/// [`Node`](crate::node::Node) or [logger](crate::logger::Logger).
 #[derive(Clone, Debug, Error)]
 pub enum BuilderError {
     #[error("Failed to create the data directory: {0:?}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@ pub mod logger;
 pub mod node;
 pub mod updater;
 
+#[cfg(feature = "logger")]
+pub use tracing::Level;
+
 pub use crate::builder::Builder;
 pub use crate::error::BuilderError;
 pub use crate::error::NodeError;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -8,10 +8,12 @@
 //! ## Behavior
 //!
 //! - **Log level**: controlled by the `RUST_LOG` environment variable, falling back to
-//!   [`LoggerConfig::log_level`] if unset.
-//! - **Target formatting**: at `INFO` and above, module paths are shortened to a human-friendly
-//!   prefix (e.g. `floresta_wire::p2p_wire::node` → `wire`). At `DEBUG` and below, the full module
-//!   path is shown.
+//!   [`Logger::log_level`] if unset.
+//! - **Target formatting**: at `INFO` and above, well-known `floresta_*` module paths are shortened
+//!   to human-friendly aliases (e.g. `floresta_wire::p2p_wire::node` → `floresta::wire`). At
+//!   `DEBUG` and below, the full module path is preserved.
+//! - **Timestamp**: at `INFO` and above, timestamps are formatted as `YYYY-MM-DD HH:MM:SS`. At
+//!   `DEBUG` and below, milliseconds are included: `YYYY-MM-DD HH:MM:SS.mmm`.
 //! - **Color**: ANSI colors are applied when writing to an interactive terminal, and stripped when
 //!   writing to a file.
 //! - **Output**: events can be emitted to `stdout`, a log file, or both.
@@ -19,25 +21,34 @@
 //! ## Example
 //!
 //! ```rust,ignore
-//! let _guard = start_logger(
-//!     &data_dir,
-//!     None,
-//!     true,  // log to stdout
-//!     true,  // log to file
-//!     Level::INFO,
-//! )?;
+//! use bdk_floresta::logger::Logger;
+//! use tracing::Level;
+//!
+//! // stdout only
+//! Logger::default().init()?;
+//!
+//! // stdout + file
+//! let _guard = Logger {
+//!     log_level: Level::DEBUG,
+//!     log_to_stdout: true,
+//!     log_file: Some("./data/debug.log".into()),
+//! }.init()?;
 //! ```
 //!
-//! The returned [`WorkerGuard`] must be kept alive for the duration of the
-//! program; dropping it will flush and stop the background logging thread.
+//! When logging to a file, the returned [`WorkerGuard`] must be kept alive
+//! for the duration of the program — dropping it will flush and shut down
+//! the background file-writing thread.
 //!
 //! [`tracing-appender`]: https://crates.io/crates/tracing-appender
 //! [`tracing-subscriber`]: https://crates.io/crates/tracing-subscriber
 
 use core::fmt;
+use std::ffi::OsStr;
 use std::fs;
 use std::io;
+use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use tracing::Level;
 use tracing_appender::non_blocking::WorkerGuard;
@@ -56,37 +67,46 @@ use tracing_subscriber::Layer;
 
 use crate::error::BuilderError;
 
-/// The default filename used for the log file when none is specified.
+/// The file which logging events are written to by default.
 pub const LOG_FILE: &str = "debug.log";
 
-/// Configuration for the logger.
+/// The string used to format the timestamp, via [`ChronoLocal`].
 ///
-/// Controls the log level and output destinations. Can be passed to the
-/// [`Builder`](crate::Builder) or used directly with [`start_logger`].
-pub struct LoggerConfig {
-    /// The minimum log level to emit. Can be overridden at runtime via `RUST_LOG`.
-    pub log_level: Level,
-    /// Whether to emit log events to `stdout`.
-    pub log_to_stdout: bool,
-    /// Whether to emit log events to a file.
-    pub log_to_file: bool,
-}
+/// Format: `YYYY-MM-DD HH:mm:ss`
+pub(crate) const CHRONO_FORMATTER: &str = "%Y-%m-%d %H:%M:%S";
 
-impl Default for LoggerConfig {
-    fn default() -> Self {
-        Self {
-            log_level: Level::INFO,
-            log_to_stdout: true,
-            log_to_file: true,
-        }
-    }
-}
+/// The string used to format the timestamp when
+/// the log level [`Level::DEBUG`] or higher, via [`ChronoLocal`].
+///
+/// Format: `YYYY-MM-DD HH:mm:ss.sss`
+pub(crate) const CHRONO_FORMATTER_DEBUG: &str = "%Y-%m-%d %H:%M:%S%.3f";
+
+/// ANSI escape code to begin dimmed text.
+pub(crate) const ANSI_DIM: &str = "\x1b[2m";
+
+/// ANSI escape code to reset all formatting.
+pub(crate) const ANSI_RESET: &str = "\x1b[0m";
+
+/// Colored `ERROR` in bright red.
+pub(crate) const COLORED_ERROR: &str = "\x1b[0;31mERROR\x1b[0m";
+
+/// Colored `WARN` in bright yellow
+pub(crate) const COLORED_WARN: &str = "\x1b[0;33m WARN\x1b[0m";
+
+/// Colored `INFO` in dim green.
+pub(crate) const COLORED_INFO: &str = "\x1b[0;32m INFO\x1b[0m";
+
+/// Colored `DEBUG` in dim blue.
+pub(crate) const COLORED_DEBUG: &str = "\x1b[0;34mDEBUG\x1b[0m";
+
+/// Colored `TRACE` in dim magenta.
+pub(crate) const COLORED_TRACE: &str = "\x1b[0;35mTRACE\x1b[0m";
 
 /// A custom [`FormatEvent`] implementation for [`tracing-subscriber`]'s `fmt` layer.
 ///
 /// Formats log events as:
 /// ```text
-/// [YYYY-MM-DD HH:MM:SS] LEVEL target: message
+/// YYYY-MM-DD HH:MM:SS LEVEL target: message
 /// ```
 ///
 /// ## Target shortening
@@ -116,12 +136,27 @@ pub struct ShortTargetFormatter {
 impl Default for ShortTargetFormatter {
     fn default() -> Self {
         Self {
-            timer: ChronoLocal::new("[%Y-%m-%d %H:%M:%S]".to_string()),
+            timer: ChronoLocal::new(CHRONO_FORMATTER.to_string()),
         }
     }
 }
 
 impl ShortTargetFormatter {
+    /// Create a new [`ShortTargetFormatter`] for the given [`Level`].
+    ///
+    /// At [`Level::DEBUG`] and below, the timestamp will include milliseconds.
+    pub fn new(level: Level) -> Self {
+        let time_fmt = if level >= Level::DEBUG {
+            CHRONO_FORMATTER_DEBUG
+        } else {
+            CHRONO_FORMATTER
+        };
+
+        Self {
+            timer: ChronoLocal::new(time_fmt.to_string()),
+        }
+    }
+
     /// Maps a full module path to a short human-friendly alias.
     ///
     /// Returns the original target unchanged if no alias is defined for it.
@@ -151,113 +186,163 @@ where
         mut writer: Writer<'_>,
         event: &tracing::Event<'_>,
     ) -> fmt::Result {
-        // Timestamp (ANSI colored if the TTY supports it).
-        if writer.has_ansi_escapes() {
-            write!(writer, "\x1b[2m")?;
+        let event_metadata = event.metadata();
+
+        // Check if the `writer` supports ANSI escape codes.
+        let writer_supports_ansi_escaping = writer.has_ansi_escapes();
+
+        // Timestamp (dimmed if the `tty` supports it).
+        if writer_supports_ansi_escaping {
+            write!(writer, "{}", ANSI_DIM)?;
         }
         self.timer.format_time(&mut writer)?;
-        if writer.has_ansi_escapes() {
-            write!(writer, "\x1b[0m ")?;
+        if writer_supports_ansi_escaping {
+            write!(writer, "{} ", ANSI_RESET)?;
         } else {
             write!(writer, " ")?;
         }
 
-        // Level (ANSI colored if the TTY supports it).
-        let meta = event.metadata();
-        if writer.has_ansi_escapes() {
-            let colored_level = match *meta.level() {
-                Level::ERROR => "\x1b[0;31mERROR\x1b[0m", // bold red
-                Level::WARN => "\x1b[0;33m WARN\x1b[0m",  // bold yellow
-                Level::INFO => "\x1b[0;32m INFO\x1b[0m",  // dimmed green
-                Level::DEBUG => "\x1b[0;34mDEBUG\x1b[0m", // dimmed blue
-                Level::TRACE => "\x1b[0;35mTRACE\x1b[0m", // dimmed magenta
+        // Level (colored if the `tty` supports it).
+        if writer_supports_ansi_escaping {
+            let colored_level = match *event_metadata.level() {
+                Level::ERROR => COLORED_ERROR,
+                Level::WARN => COLORED_WARN,
+                Level::INFO => COLORED_INFO,
+                Level::DEBUG => COLORED_DEBUG,
+                Level::TRACE => COLORED_TRACE,
             };
             write!(writer, "{} ", colored_level)?;
         } else {
-            write!(writer, "{:>5} ", meta.level())?;
+            write!(writer, "{:>5} ", event_metadata.level())?;
         }
 
-        // Target (ANSI colored if the TTY supports it).
-        let meta = event.metadata();
+        // Target (dimmed if the TTY supports it).
         let target = if tracing::enabled!(Level::DEBUG) {
-            meta.target()
+            event_metadata.target()
         } else {
-            Self::short_target(meta.target())
+            Self::short_target(event_metadata.target())
         };
-        if writer.has_ansi_escapes() {
-            write!(writer, "\x1b[2m{}\x1b[0m: ", target)?;
+        if writer_supports_ansi_escaping {
+            write!(writer, "{}{}{}: ", ANSI_DIM, target, ANSI_RESET)?;
         } else {
             write!(writer, "{}: ", target)?;
         }
 
-        // Log Message and Fields.
+        // Log message and fields.
         ctx.format_fields(writer.by_ref(), event)?;
         writeln!(writer)
     }
 }
 
-/// Start a logger that consumes tracing events and outputs them to `stdout` and/or a file.
+/// Logger configuration for the [`Node`](crate::Node).
 ///
-/// The log level is read from the `RUST_LOG` environment variable if set,
-/// otherwise `log_level` is used as the default.
+/// Controls the log level and output destinations. Can be passed to the
+/// [`Builder`](crate::Builder) via [`Builder::with_logger`](crate::Builder::with_logger),
+/// or used directly by calling [`Logger::init`].
 ///
-/// # Returns
+/// # Example
 ///
-/// Returns a [`WorkerGuard`] that must be kept alive for the duration of the
-/// program. Dropping it will flush and shut down the background logging thread.
+/// ```rust,ignore
+/// use bdk_floresta::logger::Logger;
+/// use tracing::Level;
 ///
-/// # Errors
-///
-/// Returns a [`BuilderError`] if the log file cannot be created or opened.
-pub fn start_logger(
-    data_directory: &PathBuf,
-    log_file: Option<String>,
-    log_to_stdout: bool,
-    log_to_file: bool,
-    log_level: Level,
-) -> Result<Option<WorkerGuard>, BuilderError> {
-    let make_filter = || {
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(log_level.to_string()))
-    };
+/// let _guard = Logger {
+///     log_level: Level::DEBUG,
+///     log_to_stdout: true,
+///     log_file: Some("./data/debug.log".into()),
+/// }.init()?;
+/// ```
+#[derive(Clone, Debug)]
+pub struct Logger {
+    /// The minimum log level to emit. Can be overridden at runtime via `RUST_LOG`.
+    pub log_level: Level,
+    /// Whether to emit log events to `stdout`.
+    pub log_to_stdout: bool,
+    /// The file where logging events should be written to.
+    ///
+    /// If `None`, log events will not be written to a file.
+    pub log_file: Option<PathBuf>,
+}
 
-    // Formatter for events destined to `stdout`.
-    let ansi_tty = io::IsTerminal::is_terminal(&io::stdout());
-    let fmt_layer_stdout = log_to_stdout.then(|| {
-        layer()
-            .with_writer(io::stdout)
-            .with_ansi(ansi_tty)
-            .event_format(ShortTargetFormatter::default())
-            .with_filter(make_filter())
-    });
-
-    let log_file = log_file.unwrap_or(LOG_FILE.to_string());
-
-    // Validate the log file path.
-    if log_to_file {
-        let file_path = format!("{}/{}", data_directory.to_string_lossy(), log_file);
-        fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&file_path)?;
+impl Default for Logger {
+    /// Returns a [`Logger`] that emits [`Level::INFO`] events to `stdout` only.
+    fn default() -> Self {
+        Self {
+            log_level: Level::INFO,
+            log_to_stdout: true,
+            log_file: None,
+        }
     }
+}
 
-    // Formatter for events destined to file.
-    let mut guard = None;
-    let fmt_layer_logfile = log_to_file.then(|| {
-        let file_appender = tracing_appender::rolling::never(data_directory, log_file);
-        let (non_blocking, file_guard) = tracing_appender::non_blocking(file_appender);
-        guard = Some(file_guard);
-        layer()
-            .with_writer(non_blocking)
-            .with_ansi(false)
-            .event_format(ShortTargetFormatter::default())
-            .with_filter(make_filter())
-    });
+impl Logger {
+    /// Initialize a global tracing subscriber with this configuration.
+    ///
+    /// The log level is read from the `RUST_LOG` environment variable,
+    /// if set. Otherwise, [`Logger::log_level`] is used as the default.
+    ///
+    /// If a global subscriber is already registered, this will
+    ///
+    /// # Returns
+    ///
+    /// Returns an `Option<`[`WorkerGuard`]`>` which is `Some` only when
+    /// [`Logger::log_file`] is set. The guard must be kept alive for the
+    /// duration of the program — dropping it will flush and shut down the
+    /// background file-writing thread.
+    ///
+    /// # Errors
+    ///
+    /// - Returns [`BuilderError::LoggerAlreadySetup`] if a global tracing subscriber has already
+    ///   been registered.
+    /// - Returns [`BuilderError::LoggerSetup`] if the log file cannot be created or opened.
+    pub fn init(self) -> Result<Option<WorkerGuard>, BuilderError> {
+        let make_filter = || {
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new(self.log_level.to_string()))
+        };
 
-    tracing_subscriber::registry()
-        .with(fmt_layer_stdout)
-        .with(fmt_layer_logfile)
-        .init();
+        // Formatter for events destined to `stdout`.
+        let ansi_tty = io::IsTerminal::is_terminal(&io::stdout());
+        let fmt_layer_stdout = self.log_to_stdout.then(|| {
+            layer()
+                .with_writer(io::stdout)
+                .with_ansi(ansi_tty)
+                .event_format(ShortTargetFormatter::new(self.log_level))
+                .with_filter(make_filter())
+        });
 
-    Ok(guard)
+        // Formatter for events destined to file.
+        let mut guard = None;
+        let fmt_layer_logfile = self
+            .log_file
+            .map(|log_file| -> Result<_, BuilderError> {
+                // Validate the log file path before handing it to the `tracing_appender`.
+                fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&log_file)
+                    .map_err(|e| BuilderError::LoggerSetup(Arc::new(e)))?;
+
+                let file_appender = tracing_appender::rolling::never(
+                    log_file.parent().unwrap_or(Path::new(".")),
+                    log_file.file_name().unwrap_or(OsStr::new(LOG_FILE)),
+                );
+                let (non_blocking, file_guard) = tracing_appender::non_blocking(file_appender);
+                guard = Some(file_guard);
+                Ok(layer()
+                    .with_writer(non_blocking)
+                    .with_ansi(false)
+                    .event_format(ShortTargetFormatter::new(self.log_level))
+                    .with_filter(make_filter()))
+            })
+            .transpose()?;
+
+        tracing_subscriber::registry()
+            .with(fmt_layer_stdout)
+            .with(fmt_layer_logfile)
+            .try_init()
+            .map_err(|_| BuilderError::LoggerAlreadySetup)?;
+
+        Ok(guard)
+    }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -73,7 +73,7 @@ pub struct Node {
     pub update_subscriber: Option<UnboundedReceiver<WalletUpdate>>,
     /// A guard that ensures the logger remains active for the [`Node`]'s lifetime.
     #[cfg(feature = "logger")]
-    pub(crate) _logger_guard: Option<WorkerGuard>,
+    pub(crate) _log_guard: Option<WorkerGuard>,
 }
 
 impl Node {


### PR DESCRIPTION
## Changelog
```
- Update CI workflows
  - Format
  - Remove `extractions/setup-just` dependency from CI
- Refactor the logger module
  - Rename `LoggerConfig` to `Logger`
  - Fold the `start_logger` free function into `Logger`
  - Clean up the logger module
  - Re-export `tracing`
 ```