### PR TITLE
Drop `Arc`'s from error variants

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -887,9 +887,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "halfin"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e5ddef1b50ffe7e3b734f3ff60b745e32a7c1babf70409f3520d439f300d66"
+checksum = "ede1f2f6ef69143f8cb6c9844b1f53a23e67a0bea0eab98ccb5bd0f8fe2cdd40"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.20.0",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "floresta-chain"
 version = "0.5.0"
-source = "git+https://github.com/getfloresta/Floresta.git?rev=1c7ab888ee76611436dd6a91289d0626d109501c#1c7ab888ee76611436dd6a91289d0626d109501c"
+source = "git+https://github.com/getfloresta/Floresta.git?rev=a244e9421af916680d3f17a8350a5040eefbdff5#a244e9421af916680d3f17a8350a5040eefbdff5"
 dependencies = [
  "bitcoin",
  "floresta-common",
@@ -744,7 +744,7 @@ dependencies = [
 [[package]]
 name = "floresta-common"
 version = "0.5.0"
-source = "git+https://github.com/getfloresta/Floresta.git?rev=1c7ab888ee76611436dd6a91289d0626d109501c#1c7ab888ee76611436dd6a91289d0626d109501c"
+source = "git+https://github.com/getfloresta/Floresta.git?rev=a244e9421af916680d3f17a8350a5040eefbdff5#a244e9421af916680d3f17a8350a5040eefbdff5"
 dependencies = [
  "bitcoin",
  "hashbrown 0.16.1",
@@ -756,7 +756,7 @@ dependencies = [
 [[package]]
 name = "floresta-compact-filters"
 version = "0.5.0"
-source = "git+https://github.com/getfloresta/Floresta.git?rev=1c7ab888ee76611436dd6a91289d0626d109501c#1c7ab888ee76611436dd6a91289d0626d109501c"
+source = "git+https://github.com/getfloresta/Floresta.git?rev=a244e9421af916680d3f17a8350a5040eefbdff5#a244e9421af916680d3f17a8350a5040eefbdff5"
 dependencies = [
  "bitcoin",
  "floresta-chain",
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "floresta-mempool"
 version = "0.5.0"
-source = "git+https://github.com/getfloresta/Floresta.git?rev=1c7ab888ee76611436dd6a91289d0626d109501c#1c7ab888ee76611436dd6a91289d0626d109501c"
+source = "git+https://github.com/getfloresta/Floresta.git?rev=a244e9421af916680d3f17a8350a5040eefbdff5#a244e9421af916680d3f17a8350a5040eefbdff5"
 dependencies = [
  "ahash",
  "bitcoin",
@@ -778,7 +778,7 @@ dependencies = [
 [[package]]
 name = "floresta-wire"
 version = "0.5.0"
-source = "git+https://github.com/getfloresta/Floresta.git?rev=1c7ab888ee76611436dd6a91289d0626d109501c#1c7ab888ee76611436dd6a91289d0626d109501c"
+source = "git+https://github.com/getfloresta/Floresta.git?rev=a244e9421af916680d3f17a8350a5040eefbdff5#a244e9421af916680d3f17a8350a5040eefbdff5"
 dependencies = [
  "bip324",
  "bitcoin",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -659,7 +659,7 @@ dependencies = [
 [[package]]
 name = "floresta-chain"
 version = "0.5.0"
-source = "git+https://github.com/getfloresta/Floresta.git?rev=1c7ab888ee76611436dd6a91289d0626d109501c#1c7ab888ee76611436dd6a91289d0626d109501c"
+source = "git+https://github.com/getfloresta/Floresta.git?rev=a244e9421af916680d3f17a8350a5040eefbdff5#a244e9421af916680d3f17a8350a5040eefbdff5"
 dependencies = [
  "bitcoin",
  "floresta-common",
@@ -675,7 +675,7 @@ dependencies = [
 [[package]]
 name = "floresta-common"
 version = "0.5.0"
-source = "git+https://github.com/getfloresta/Floresta.git?rev=1c7ab888ee76611436dd6a91289d0626d109501c#1c7ab888ee76611436dd6a91289d0626d109501c"
+source = "git+https://github.com/getfloresta/Floresta.git?rev=a244e9421af916680d3f17a8350a5040eefbdff5#a244e9421af916680d3f17a8350a5040eefbdff5"
 dependencies = [
  "bitcoin",
  "hashbrown 0.16.1",
@@ -687,7 +687,7 @@ dependencies = [
 [[package]]
 name = "floresta-compact-filters"
 version = "0.5.0"
-source = "git+https://github.com/getfloresta/Floresta.git?rev=1c7ab888ee76611436dd6a91289d0626d109501c#1c7ab888ee76611436dd6a91289d0626d109501c"
+source = "git+https://github.com/getfloresta/Floresta.git?rev=a244e9421af916680d3f17a8350a5040eefbdff5#a244e9421af916680d3f17a8350a5040eefbdff5"
 dependencies = [
  "bitcoin",
  "floresta-chain",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "floresta-mempool"
 version = "0.5.0"
-source = "git+https://github.com/getfloresta/Floresta.git?rev=1c7ab888ee76611436dd6a91289d0626d109501c#1c7ab888ee76611436dd6a91289d0626d109501c"
+source = "git+https://github.com/getfloresta/Floresta.git?rev=a244e9421af916680d3f17a8350a5040eefbdff5#a244e9421af916680d3f17a8350a5040eefbdff5"
 dependencies = [
  "ahash",
  "bitcoin",
@@ -709,7 +709,7 @@ dependencies = [
 [[package]]
 name = "floresta-wire"
 version = "0.5.0"
-source = "git+https://github.com/getfloresta/Floresta.git?rev=1c7ab888ee76611436dd6a91289d0626d109501c#1c7ab888ee76611436dd6a91289d0626d109501c"
+source = "git+https://github.com/getfloresta/Floresta.git?rev=a244e9421af916680d3f17a8350a5040eefbdff5#a244e9421af916680d3f17a8350a5040eefbdff5"
 dependencies = [
  "bip324",
  "bitcoin",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -796,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "halfin"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e5ddef1b50ffe7e3b734f3ff60b745e32a7c1babf70409f3520d439f300d66"
+checksum = "ede1f2f6ef69143f8cb6c9844b1f53a23e67a0bea0eab98ccb5bd0f8fe2cdd40"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.20.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ dns-lookup = { version = "2.1.1" }
 time = { version = "0.3.45" } # time 0.3.47+ requires 1.88.0, but MSRV is 1.85.0
 
 [dev-dependencies]
+halfin = { version = "0.3.0" }
 anyhow = { version = "1.0.75" } # v1.0.75 is needed for `anyhow::Ok()`
-halfin = { version = "0.2.1" }
 tokio = { version = "1.50", features = ["macros", "rt-multi-thread"] }
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,10 @@ toml = { version = "1.0" }
 [dependencies]
 bitcoin = { version = "0.32.7" }
 bdk_wallet = { version = "2.3" }
-floresta-chain = { git = "https://github.com/getfloresta/Floresta.git", rev = "1c7ab888ee76611436dd6a91289d0626d109501c", features = ["flat-chainstore"] }
-floresta-compact-filters = { git = "https://github.com/getfloresta/Floresta.git", rev = "1c7ab888ee76611436dd6a91289d0626d109501c" }
-floresta-mempool = { git = "https://github.com/getfloresta/Floresta.git", rev = "1c7ab888ee76611436dd6a91289d0626d109501c" }
-floresta-wire = { git = "https://github.com/getfloresta/Floresta.git", rev = "1c7ab888ee76611436dd6a91289d0626d109501c" }
+floresta-chain = { git = "https://github.com/getfloresta/Floresta.git", rev = "a244e9421af916680d3f17a8350a5040eefbdff5", features = ["flat-chainstore"] }
+floresta-compact-filters = { git = "https://github.com/getfloresta/Floresta.git", rev = "a244e9421af916680d3f17a8350a5040eefbdff5" }
+floresta-mempool = { git = "https://github.com/getfloresta/Floresta.git", rev = "a244e9421af916680d3f17a8350a5040eefbdff5" }
+floresta-wire = { git = "https://github.com/getfloresta/Floresta.git", rev = "a244e9421af916680d3f17a8350a5040eefbdff5" }
 thiserror = { version = "2.0" }
 tokio = { version = "1.50", features = ["rt", "signal", "sync", "time"] }
 tracing = { version = "0.1.41" }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p>
     <!-- <a href="https://crates.io/crates/bdk_floresta"><img src="https://img.shields.io/crates/v/bdk_floresta.svg"/></a> -->
     <!-- <a href="https://docs.rs/bdk_floresta"><img src="https://img.shields.io/badge/docs.rs-bdk--floresta-brightgreen"/></a> -->
-    <a href="https://blog.rust-lang.org/2025/02/20/Rust-1.85.0/"><img src="https://img.shields.io/badge/rustc-1.85.0%2B-orange.svg"/></a>
+    <a href="https://blog.rust-lang.org/2025/02/20/Rust-1.85.0/"><img src="https://img.shields.io/badge/MSRV-1.85.0%2B-orange.svg"/></a>
     <a href="https://github.com/luisschwab/bdk-floresta/blob/master/LICENSE"><img src="https://img.shields.io/badge/License-MIT%2FApache--2.0-red.svg"/></a>
     <a href="https://github.com/luisschwab/bdk-floresta/actions/workflows/rust.yml"><img src="https://github.com/luisschwab/bdk-floresta/actions/workflows/rust.yml/badge.svg"></a>
     <a href="https://github.com/luisschwab/bdk-floresta/actions/workflows/integration.yml"><img src="https://github.com/luisschwab/bdk-floresta/actions/workflows/integration.yml/badge.svg"></a>

--- a/README.md
+++ b/README.md
@@ -24,32 +24,36 @@ making it possible for every wallet to have it's own node.
 
 ## Developing
 
-This project uses [`cargo-rbmt`](https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools/tree/master/cargo-rbmt)
-to manage everything related to `cargo`, such as formatting, linting, testing and CI. To install it, run:
+This project uses [`just`](https://github.com/casey/just) for command running, and
+[`cargo-rbmt`](https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools/tree/master/cargo-rbmt)
+to manage everything related to `cargo`, such as formatting, linting, testing and CI. To install them, run:
 
 ```console
-% cargo install cargo-rbmt
+~$ cargo install just
+
+~$ cargo install cargo-rbmt
 ```
 
 A `justfile` is provided for convenience. Run `just` to see available commands:
 
 ```console
-% just
-> bdk-floresta
+~$ > bdk-floresta
 > A Floresta-powered chain-source crate for BDK
 
-> Available recipes:
-    build                 # Build `bdk-floresta` and examples [alias: b]
-    check                 # Check code formatting, compilation, linting, and commit signature [alias: c]
-    check-features        # Check that all feature combinations compile
-    check-sigs            # Checks whether all commits in this branch are signed
-    delete item="example" # Delete files: example, target, lockfiles [alias: d]
-    doc                   # Generate documentation
-    doc-open              # Generate and open documentation
-    example name="node"   # Run an example crate [alias: e]
-    fmt                   # Format code [alias: f]
-    lock                  # Regenerate `Cargo-recent.lock` and `Cargo-minimal.lock`
-    msrv                  # Verify the library builds with MSRV (1.85.0)
+Available recipes:
+    build              # Build `bdk-floresta` and examples [alias: b]
+    check              # Check code formatting, compilation, linting, and commit signatures [alias: c]
+    check-features     # Check that all feature combinations compile
+    check-sigs         # Check if commits are PGP-signed
+    delete item="data" # Delete files: data, target, lockfiles [alias: d]
+    doc                # Generate documentation
+    doc-open           # Generate and open documentation
+    example-regtest    # Run the `regtest` example [alias: reg]
+    example-signet     # Run the `signet` example [alias: sig]
+    fmt                # Format code [alias: f]
+    lock               # Regenerate `Cargo-recent.lock` and `Cargo-minimal.lock` [alias: l]
+    msrv               # Check if this library builds with the MSRV toolchain
+    pre-push           # Perform pre-push checks:  [alias: p]
 ```
 
 ## Architecture

--- a/examples/regtest.rs
+++ b/examples/regtest.rs
@@ -1,6 +1,22 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! IBD integration test between `bdk_floresta`, `utreexod` and `bitcoind` on regtest.
+//! Regtest integration test between [`bdk_floresta`], [`bitcoind`] and [`utreexod`].
+//!
+//! ## Network Topology
+//!
+//! ```text
+//!  ┌──────────┐   P2P    ┌──────────┐        P2P        ┌──────────────┐
+//!  │ bitcoind │ <======> │ utreexod │ <===============> │ bdk_floresta │
+//!  └──────────┘  blocks  └──────────┘  blocks + proofs  └──────────────┘
+//! ```
+//!
+//! 1. [`bitcoind`] mines blocks and propagates them to [`utreexod`].
+//! 2. [`utreexod`] receives these blocks and builds Utreexo Merkle proofs for these blocks.
+//! 3. [`bdk_floresta`] requests blocks and Utreexo Merkle proofs (`uproof`) from [`utreexod`].
+//!
+//! [`bdk_floresta`]: bdk_floresta::Node
+//! [`bitcoind`]: halfin::BitcoinD
+//! [`utreexod`]: halfin::UtreexoD
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -10,14 +26,16 @@ use bdk_floresta::logger::Logger;
 use bdk_floresta::Builder;
 use bitcoin::Network;
 use halfin::bitcoind::BitcoinD;
+use halfin::bitcoind::BitcoinDConf;
 use halfin::utreexod::UtreexoD;
+use halfin::utreexod::UtreexoDConf;
 use halfin::wait_for_height;
 use tracing::info;
 use tracing::Level;
 
 const BLOCK_COUNT: u32 = 144;
 const NETWORK: Network = Network::Regtest;
-const DATA_DIR: &str = "./examples/data/regtest_ibd/";
+const DATA_DIR: &str = "./examples/data/regtest/";
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -29,12 +47,16 @@ async fn main() -> anyhow::Result<()> {
     }
     .init()?;
 
-    // Spawn a BitcoinD
+    // Configure and spawn a BitcoinD
     info!("> Spawning BitcoinD...");
-    let bitcoind = BitcoinD::new()?;
-    info!("> BitcoinD spawned");
+    let bitcoind_conf = BitcoinDConf {
+        staticdir: Some(PathBuf::from(DATA_DIR).join("bitcoind")),
+        ..Default::default()
+    };
+    let bitcoind = BitcoinD::new_with_conf(&bitcoind_conf)?;
+    info!("> Spawned BitcoinD");
 
-    // Mine blocks.
+    // Mine the first batch of blocks
     info!("> Mining {} blocks...", BLOCK_COUNT);
     let hashes = bitcoind.generate(BLOCK_COUNT)?;
     info!(
@@ -44,10 +66,14 @@ async fn main() -> anyhow::Result<()> {
         &hashes.last().unwrap().to_string()[..8],
     );
 
-    // Spawn an UtreexoD
+    // Configure and spawn an UtreexoD
     info!("> Spawning UtreexoD...");
-    let utreexod = UtreexoD::new()?;
-    info!("> UtreexoD spawned");
+    let utreexod_conf = UtreexoDConf {
+        staticdir: Some(PathBuf::from(DATA_DIR).join("utreexod")),
+        ..Default::default()
+    };
+    let utreexod = UtreexoD::new_with_conf(&utreexod_conf)?;
+    info!("> Spawned UtreexoD");
 
     // Connect BitcoinD and UtreexoD
     info!("> Connecting BitcoinD and UtreexoD... ");
@@ -63,7 +89,7 @@ async fn main() -> anyhow::Result<()> {
     // Configure the bdk_floresta node
     let node_config = NodeConfig {
         network: NETWORK,
-        data_directory: PathBuf::from(DATA_DIR),
+        data_directory: PathBuf::from(DATA_DIR).join("bdk_floresta").join("regtest"),
         ..Default::default()
     };
 
@@ -74,51 +100,145 @@ async fn main() -> anyhow::Result<()> {
     info!("> bdk_floresta is spawned");
     std::thread::sleep(Duration::from_secs(2));
 
-    // Connect bdk_floresta to BitcoinD
-    info!("> Connecting BitcoinD and bdk_floresta");
-    node.add_peer(&bitcoind.get_p2p_socket()).await?;
-    std::thread::sleep(Duration::from_secs(2));
-    assert_eq!(node.get_peer_info().await?.len(), 1);
-    info!("> BitcoinD and bdk_floresta are connected");
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            info!("> /exit");
+            node.shutdown().await?;
+            return Ok(());
+        }
+        result = async {
+            // Connect bdk_floresta to BitcoinD
+            info!("> Connecting BitcoinD and bdk_floresta");
+            node.add_peer(&bitcoind.get_p2p_socket()).await?;
+            std::thread::sleep(Duration::from_secs(2));
+            assert_eq!(node.get_peer_info().await?.len(), 1);
+            info!("> BitcoinD and bdk_floresta are connected");
 
-    // Connect bdk_floresta to UtreexoD
-    info!("> Connecting bdk_floresta and BitcoinD...");
-    node.add_peer(&utreexod.get_p2p_socket()).await?;
-    std::thread::sleep(Duration::from_secs(2));
-    assert_eq!(node.get_peer_info().await?.len(), 2);
+            // Connect bdk_floresta to UtreexoD
+            info!("> Connecting bdk_floresta and BitcoinD...");
+            node.add_peer(&utreexod.get_p2p_socket()).await?;
+            std::thread::sleep(Duration::from_secs(2));
+            assert_eq!(node.get_peer_info().await?.len(), 2);
 
-    // Wait for bdk_floresta to catch up
-    while node.get_node_height()? < BLOCK_COUNT {
-        tokio::time::sleep(Duration::from_millis(100)).await;
+            // Wait for bdk_floresta to catch up to the first batch
+            info!("> Waiting for bdk_floresta to catch up to block {}...", BLOCK_COUNT);
+            while node.get_node_height()? < BLOCK_COUNT {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            info!("> bdk_floresta caught up to block {}", BLOCK_COUNT);
+
+            // Print bdk_floresta's peer information
+            let peer_info = node.get_peer_info().await?;
+            info!("> Connected peers ({}):", peer_info.len());
+            for (i, peer) in peer_info.iter().enumerate() {
+                info!("  > Peer {}:", i);
+                info!("    > User Agent: {}", peer.user_agent);
+                info!("    > Socket: {}", peer.address);
+                info!("    > Transport Protocol: {:?}", peer.transport_protocol);
+                info!("    > Services: {}", peer.services);
+            }
+
+            // Get the hash of the block at the tip
+            let block_hash = node.get_block_hash(BLOCK_COUNT)?;
+            info!("> Hash of the block at the tip: {}", block_hash);
+
+            // Fetch the block at the tip from a peer and show its header
+            let block = node.fetch_block(block_hash).await?.unwrap();
+            info!("> Header of the block at the tip: {:#?}", block.header);
+
+            // Get bdk_floresta's Utreexo accumulator state
+            let stump = node.get_accumulator();
+            info!("> bdk_floresta accumulator state: {:?}", stump);
+
+            /*
+
+            // Doesn't work: bdk_floresta won't sync the new
+            // blocks after it switches from IBD to running node
+
+            // Mine a second batch of blocks
+            info!("> Mining {} more blocks...", BLOCK_COUNT);
+            let hashes = bitcoind.generate(BLOCK_COUNT)?;
+            info!(
+                "> Mined {} blocks [{}..{}]",
+                BLOCK_COUNT,
+                &hashes.first().unwrap().to_string()[..8],
+                &hashes.last().unwrap().to_string()[..8],
+            );
+
+            // Wait for UtreexoD to catch up to the second batch
+            info!("> Waiting for UtreexoD to catch up to block {}...", 2 * BLOCK_COUNT);
+            wait_for_height(&utreexod, 2 * BLOCK_COUNT)?;
+            info!("> UtreexoD caught up to block {}", 2 * BLOCK_COUNT);
+
+            // Configure and spawn a second UtreexoD
+            info!("> Spawning a second UtreexoD...");
+            let utreexod_2_conf = UtreexoDConf {
+                staticdir: Some(PathBuf::from(DATA_DIR).join("utreexod_2")),
+                ..Default::default()
+            };
+            let utreexod_2 = UtreexoD::new_with_conf(&utreexod_2_conf)?;
+            info!("> Second UtreexoD spawned");
+
+            // Connect BitcoinD and second UtreexoD
+            info!("> Connecting BitcoinD and the second UtreexoD... ");
+            utreexod_2.add_peer(bitcoind.get_p2p_socket())?;
+            assert_eq!(utreexod_2.get_peer_count()?, 1);
+            info!("> BitcoinD and second UtreexoD are connected");
+
+            // Wait for the second UtreexoD to catch up
+            info!("> Waiting for the second UtreexoD to catch up to block {}...", 2 * BLOCK_COUNT);
+            wait_for_height(&utreexod_2, 2 * BLOCK_COUNT)?;
+            info!("> Second UtreexoD caught up to block {}", 2 * BLOCK_COUNT);
+
+            // Connect bdk_floresta and the second UtreexoD
+            node.add_peer(&utreexod_2.get_p2p_socket()).await?;
+
+            // Give peers time to propagate the new tip to bdk_floresta
+            tokio::time::sleep(Duration::from_secs(5)).await;
+
+            // Print bdk_floresta's peer information
+            let peer_info = node.get_peer_info().await?;
+            info!("> Connected peers ({}):", peer_info.len());
+            for (i, peer) in peer_info.iter().enumerate() {
+                info!("  > Peer {}:", i);
+                info!("    > User Agent: {}", peer.user_agent);
+                info!("    > Socket: {}", peer.address);
+                info!("    > Transport Protocol: {:?}", peer.transport_protocol);
+                info!("    > Services: {}", peer.services);
+            }
+
+            // Wait for bdk_floresta to catch up to the second batch
+            info!("> Waiting for bdk_floresta to catch up to block {}...", 2 * BLOCK_COUNT);
+            while node.get_node_height()? < 2 * BLOCK_COUNT {
+                tokio::time::sleep(Duration::from_secs(3)).await;
+                info!("> Current Height: {}", node.get_chain_height()?);
+            }
+
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            info!("> bdk_floresta caught up to block {}", 2 * BLOCK_COUNT);
+
+            // Get the hash of the block at the new tip
+            let block_hash = node.get_block_hash(2 * BLOCK_COUNT)?;
+            info!("> Hash of the block at the tip: {}", block_hash);
+
+            // Fetch the block at the new tip from a peer and show its header
+            let block = node.fetch_block(block_hash).await?.unwrap();
+            info!("> Header of the block at the tip: {:#?}", block.header);
+
+            // Get bdk_floresta's updated Utreexo accumulator state
+            let stump = node.get_accumulator();
+            info!("> bdk_floresta accumulator state: {:?}", stump);
+
+            */
+
+            info!("> /exit");
+            node.shutdown().await?;
+
+            Ok::<_, anyhow::Error>(())
+        } => {
+            result?;
+        }
     }
-
-    // Print bdk_floresta's peer information
-    let peer_info = node.get_peer_info().await?;
-    info!("> Connected peers ({}):", peer_info.len());
-    for (i, peer) in peer_info.iter().enumerate() {
-        info!("  > Peer {}:", i);
-        info!("    > User Agent: {}", peer.user_agent);
-        info!("    > Socket: {}", peer.address);
-        info!("    > Transport Protocol: {:?}", peer.transport_protocol);
-        info!("    > Services: {}", peer.services);
-    }
-
-    // Get the the hash of the block of arbitrary height from the node's chainstate
-    let block_hash = node.get_block_hash(BLOCK_COUNT)?;
-    info!("> Hash of the block at the tip: {}", block_hash);
-
-    // Fetch a block of arbitrary height from a peer and show it's header
-    let block = node.fetch_block(block_hash).await?.unwrap();
-    info!("> Header of the block at the tip: {:#?}", block.header);
-
-    // Get bdk_floresta's Utreexo accumulator state
-    let stump = node.get_accumulator();
-    info!("> bdk_floresta accumulator state: {:?}", stump);
-
-    // TODO(@luisschwab): mine more blocks and have bdk_floresta sync up
-
-    info!("> /exit");
-    node.shutdown().await?;
 
     Ok(())
 }

--- a/examples/regtest.rs
+++ b/examples/regtest.rs
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
     info!("> Mining {} blocks...", BLOCK_COUNT);
     let hashes = bitcoind.generate(BLOCK_COUNT)?;
     info!(
-        "Mined {} blocks [{}..{}]",
+        "> Mined {} blocks [{}..{}]",
         BLOCK_COUNT,
         &hashes.first().unwrap().to_string()[..8],
         &hashes.last().unwrap().to_string()[..8],
@@ -88,7 +88,7 @@ async fn main() -> anyhow::Result<()> {
     assert_eq!(node.get_peer_info().await?.len(), 2);
 
     // Wait for bdk_floresta to catch up
-    while node.get_validation_height()? < BLOCK_COUNT {
+    while node.get_node_height()? < BLOCK_COUNT {
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
@@ -112,7 +112,7 @@ async fn main() -> anyhow::Result<()> {
     info!("> Header of the block at the tip: {:#?}", block.header);
 
     // Get bdk_floresta's Utreexo accumulator state
-    let stump = node.get_accumulator()?;
+    let stump = node.get_accumulator();
     info!("> bdk_floresta accumulator state: {:?}", stump);
 
     // TODO(@luisschwab): mine more blocks and have bdk_floresta sync up

--- a/examples/signet.rs
+++ b/examples/signet.rs
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Signet integration test between [`bdk_floresta`] and the Bitcoin signet P2P network.
+
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -10,7 +14,7 @@ use tracing::info;
 use tracing::Level;
 
 const NETWORK: Network = Network::Signet;
-const DATA_DIR: &str = "./examples/data/signet_ibd/";
+const DATA_DIR: &str = "./examples/data/signet/";
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -18,14 +22,14 @@ async fn main() -> anyhow::Result<()> {
     let _logger = Logger {
         log_level: Level::INFO,
         log_to_stdout: true,
-        log_file: Some(PathBuf::from(DATA_DIR).join(LOG_FILE)),
+        log_file: Some(PathBuf::from(DATA_DIR).join("bdk_floresta").join(LOG_FILE)),
     }
     .init()?;
 
     // Configure the node
     let config = NodeConfig {
         network: NETWORK,
-        data_directory: PathBuf::from(DATA_DIR),
+        data_directory: PathBuf::from(DATA_DIR).join("bdk_floresta"),
         ..Default::default()
     };
 
@@ -37,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {
-                info!("> Shutting down...");
+                info!("> /exit");
                 node.shutdown().await?;
                 return Ok(());
         }

--- a/examples/signet.rs
+++ b/examples/signet.rs
@@ -48,14 +48,14 @@ async fn main() -> anyhow::Result<()> {
                 tokio::time::sleep(Duration::from_secs(10)).await;
                 info!(
                     "> Waiting for the node to catch up to the chain tip... [{}/{}]",
-                    node.get_validation_height()?,
-                    node.get_height()?,
+                    node.get_node_height()?,
+                    node.get_chain_height()?,
                 );
             }
             info!("> Finished IBD");
 
             // Get the node's Utreexo accumulator state
-            let stump = node.get_accumulator()?;
+            let stump = node.get_accumulator();
             info!("> bdk_floresta accumulator state: {:?}", stump);
 
             // Print the node's peer information
@@ -68,7 +68,7 @@ async fn main() -> anyhow::Result<()> {
             }
 
             // Get the hash of the block at the tip
-            let tip = node.get_height()?;
+            let tip = node.get_chain_height()?;
             let block_hash = node.get_block_hash(tip)?;
             info!("> Hash of the block at the tip: {}", block_hash);
 

--- a/justfile
+++ b/justfile
@@ -1,14 +1,15 @@
 alias b := build
 alias c := check
 alias d := delete
-alias e := example
+alias reg := example-regtest
+alias sig := example-signet
 alias f := fmt
 alias l := lock
 alias p := pre-push
 
 _default:
     @echo "> bdk-floresta"
-    @echo "> A Floresta-powered chain-source crate for BDK"
+    @echo "> A Floresta-powered chain-source crate for BDK\n"
     @just --list
 
 [doc: "Build `bdk-floresta` and examples"]
@@ -43,10 +44,15 @@ doc:
 doc-open:
     cargo rbmt docs --open
 
-[doc: "Run an example: `regtest`, `signet`"]
-example name="regtest":
-    rm -rf examples/data/regtest_ibd
-    cargo run --release --example {{ name }}
+[doc: "Run the `regtest` example"]
+example-regtest:
+    rm -rf examples/data/regtest
+    cargo run --release --example regtest
+
+[doc: "Run the `signet` example"]
+example-signet:
+    rm -rf examples/data/signet
+    cargo run --release --example signet
 
 [doc: "Format code"]
 fmt:

--- a/justfile
+++ b/justfile
@@ -4,6 +4,7 @@ alias d := delete
 alias e := example
 alias f := fmt
 alias l := lock
+alias p := pre-push
 
 _default:
     @echo "> bdk-floresta"
@@ -58,6 +59,13 @@ lock:
 [doc: "Check if this library builds with the MSRV toolchain"]
 msrv:
     cargo rbmt test --toolchain msrv --lock-file minimal
+
+[doc: "Perform pre-push checks: "]
+pre-push:
+    @just check-sigs
+    @just check
+    @just doc
+    @just msrv
 
 _delete-data:
     rm -rf examples/data

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -16,7 +16,6 @@ use bitcoin::Network;
 use floresta_chain::pruned_utreexo::flat_chain_store::FlatChainStore;
 use floresta_chain::pruned_utreexo::flat_chain_store::FlatChainStoreConfig;
 use floresta_chain::AssumeValidArg;
-use floresta_chain::BlockchainError;
 use floresta_chain::BlockchainInterface;
 use floresta_chain::ChainParams;
 use floresta_chain::ChainState;
@@ -34,7 +33,6 @@ use tokio::sync::mpsc::unbounded_channel;
 use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
-use tracing::error;
 use tracing::info;
 
 use crate::error::BuilderError;
@@ -251,7 +249,7 @@ impl Builder {
                 &self.node_configuration.reachable_nets,
             ),
         )
-        .map_err(|e| BuilderError::BuildInner(e.to_string()))?;
+        .map_err(BuilderError::BuildInner)?;
 
         // Get a handle to interact with the [`Node`].
         let node_handle: NodeInterface = node_inner.get_handle();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -212,48 +212,34 @@ impl Builder {
         );
 
         // Try to load an existing [`FlatChainStore`] from the file system, or create a new one.
-        let flat_chain_store: FlatChainStore = match FlatChainStore::new(chain_store_cfg.clone()) {
-            Ok(store) => store,
-            Err(e) => {
-                error!("Failed to open FlatChainStore: {:?}", e);
-                return Err(e.into());
-            }
-        };
+        let chain_store: FlatChainStore =
+            FlatChainStore::new(chain_store_cfg.clone()).map_err(BuilderError::ChainStoreInit)?;
 
-        // Load an existing [`ChainState`] from the [`FlatChainStore`], or create a new one.
-        //
-        // TODO: unify `ChainState::new` and `ChainState::load_chain_state`
-        // upstream and change it here.
+        // Initialize a [`ChainState`] from the [`FlatChainStore`].
         let chain_state: Arc<ChainState<FlatChainStore>> = Arc::new(
-            ChainState::load_chain_state(
-                flat_chain_store,
+            ChainState::open(
+                chain_store,
                 self.node_configuration.network,
                 AssumeValidArg::Hardcoded,
             )
-            .or_else(|e| match e {
-                BlockchainError::ChainNotInitialized => Ok(ChainState::new(
-                    FlatChainStore::new(chain_store_cfg.clone())?,
-                    self.node_configuration.network,
-                    AssumeValidArg::Hardcoded,
-                )),
-                e => Err(BuilderError::ChainState(Arc::new(e))),
-            })?,
+            .map_err(BuilderError::ChainState)?,
         );
 
-        // Create the [`FlatFiltersStore`]'s configuration.
-        let flat_filters_store =
+        // Configure the [`FlatFiltersStore`].
+        let filter_store =
             FlatFiltersStore::new(self.node_configuration.data_directory.join("cbf"));
-        let filters = Arc::new(NetworkFilters::new(flat_filters_store));
+        let filters = Arc::new(NetworkFilters::new(filter_store));
+
         info!("FilterStore loaded at height {}", filters.get_height()?);
 
         // A kill signal that keeps track of whether the [`Node`] should stop.
         let kill_signal: Arc<RwLock<bool>> = Arc::new(RwLock::new(false));
 
-        // Create the node's mempool.
+        // Create the [`Node`]'s mempool.
         let mempool_size_bytes = 1_000_000 * self.node_configuration.mempool_size;
         let mempool: Arc<Mutex<Mempool>> = Arc::new(Mutex::new(Mempool::new(mempool_size_bytes)));
 
-        // Encapsulate `UtreexoNode` into an inner of `Node`.
+        // Encapsulate [`UtreexoNode`] as an inner of [`Node`].
         let node_inner = UtreexoNode::<_, RunningNode>::new(
             self.node_configuration.clone().into(),
             chain_state.clone(),
@@ -267,7 +253,7 @@ impl Builder {
         )
         .map_err(|e| BuilderError::BuildInner(e.to_string()))?;
 
-        // Get a handle to interact with the `Node`.
+        // Get a handle to interact with the [`Node`].
         let node_handle: NodeInterface = node_inner.get_handle();
 
         // Set up the [`Wallet`]'s update channel, sender and receiver.

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,53 +11,47 @@ use thiserror::Error;
 
 /// Errors which might occur when building the
 /// [`Node`](crate::node::Node) or [logger](crate::logger::Logger).
-#[derive(Clone, Debug, Error)]
+#[derive(Debug, Error)]
 pub enum BuilderError {
     #[error("Failed to create the data directory: {0:?}")]
-    CreateDirectory(Arc<std::io::Error>),
+    CreateDirectory(#[from] std::io::Error),
 
     #[error("Failed to create a ChainState: {0:?}")]
-    ChainState(Arc<floresta_chain::BlockchainError>),
+    ChainState(#[from] floresta_chain::BlockchainError),
 
     #[error("Failed to setup the tracing subscriber logger: {0:?}")]
-    LoggerSetup(Arc<std::io::Error>),
+    LoggerSetup(std::io::Error),
 
     #[error("Tracing subscriber logger already initialized")]
     LoggerAlreadySetup,
 
     #[error("Failed to load or create a new chain store: {0:?}")]
-    ChainStoreInit(Arc<floresta_chain::FlatChainstoreError>),
+    ChainStoreInit(floresta_chain::FlatChainstoreError),
 
     #[error("Node and Wallet are not on the same network")]
     NetworkMismatch,
 
     #[error("Compact Block Filter error: {0:?}")]
-    CompactBlockFilter(Arc<floresta_compact_filters::IterableFilterStoreError>),
+    CompactBlockFilter(floresta_compact_filters::IterableFilterStoreError),
 
     #[error("Failed to build the inner node: {0}")]
-    BuildInner(String),
-}
-
-impl From<std::io::Error> for BuilderError {
-    fn from(err: std::io::Error) -> Self {
-        BuilderError::CreateDirectory(Arc::new(err))
-    }
+    BuildInner(floresta_wire::error::WireError),
 }
 
 impl From<floresta_chain::FlatChainstoreError> for BuilderError {
     fn from(err: floresta_chain::FlatChainstoreError) -> Self {
-        BuilderError::ChainStoreInit(Arc::new(err))
+        BuilderError::ChainStoreInit(err)
     }
 }
 
 impl From<floresta_compact_filters::IterableFilterStoreError> for BuilderError {
     fn from(err: floresta_compact_filters::IterableFilterStoreError) -> Self {
-        BuilderError::CompactBlockFilter(Arc::new(err))
+        BuilderError::CompactBlockFilter(err)
     }
 }
 
 /// Errors which might occur when running the [`Node`](crate::node::Node).
-#[derive(Clone, Debug, Error)]
+#[derive(Debug, Error)]
 pub enum NodeError {
     /// The [`Node`](crate::node::Node) is already running.
     #[error("The node is already running")]
@@ -71,9 +65,9 @@ pub enum NodeError {
     #[error(transparent)]
     Receiver(#[from] tokio::sync::oneshot::error::RecvError),
 
-    /// The [`Node`](crate::node::Node) threw an error while persisting data to the file system.
-    #[error("Persistence error: {0:?}")]
-    Persistence(Arc<Box<dyn floresta_chain::DatabaseError>>),
+    /// The [`Node`](crate::node::Node) failed to flush the chain state to disk.
+    #[error("Failed to flush chain state: {0:?}")]
+    Flush(floresta_chain::BlockchainError),
 
     /// I/O error during persistence.
     #[error("I/O error: {0}")]
@@ -81,11 +75,11 @@ pub enum NodeError {
 
     /// Blockchain related errors.
     #[error("Blockchain error: {0:?}")]
-    Blockchain(Arc<floresta_chain::BlockchainError>),
+    Blockchain(floresta_chain::BlockchainError),
 
     /// Mempool related errors.
     #[error("Mempool acceptance error: {0:?}")]
-    Mempool(Arc<floresta_mempool::mempool::AcceptToMempoolError>),
+    Mempool(floresta_mempool::mempool::AcceptToMempoolError),
 }
 
 impl From<std::io::Error> for NodeError {
@@ -96,12 +90,12 @@ impl From<std::io::Error> for NodeError {
 
 impl From<floresta_chain::BlockchainError> for NodeError {
     fn from(err: floresta_chain::BlockchainError) -> Self {
-        NodeError::Blockchain(Arc::new(err))
+        NodeError::Blockchain(err)
     }
 }
 
 impl From<floresta_mempool::mempool::AcceptToMempoolError> for NodeError {
     fn from(err: floresta_mempool::mempool::AcceptToMempoolError) -> Self {
-        NodeError::Mempool(Arc::new(err))
+        NodeError::Mempool(err)
     }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -48,7 +48,6 @@ use std::fs;
 use std::io;
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use tracing::Level;
 use tracing_appender::non_blocking::WorkerGuard;
@@ -318,14 +317,13 @@ impl Logger {
             .map(|log_file| -> Result<_, BuilderError> {
                 // Validate the log file path before handing it to the `tracing_appender`.
                 if let Some(parent) = log_file.parent() {
-                    fs::create_dir_all(parent)
-                        .map_err(|e| BuilderError::LoggerSetup(Arc::new(e)))?;
+                    fs::create_dir_all(parent).map_err(BuilderError::LoggerSetup)?;
                 }
                 fs::OpenOptions::new()
                     .create(true)
                     .append(true)
                     .open(&log_file)
-                    .map_err(|e| BuilderError::LoggerSetup(Arc::new(e)))?;
+                    .map_err(BuilderError::LoggerSetup)?;
 
                 let file_appender = tracing_appender::rolling::never(
                     log_file.parent().unwrap_or(Path::new(".")),

--- a/src/node.rs
+++ b/src/node.rs
@@ -169,9 +169,8 @@ impl Node {
     }
 
     /// Get the [`Node`]'s current [`NodeConfig`].
-    pub async fn get_config(&self) -> Result<NodeConfig, NodeError> {
-        let config = self.config.clone();
-        Ok(config)
+    pub fn get_config(&self) -> NodeConfig {
+        self.config.clone()
     }
 
     /// Check if the [`Node`] is still performing Initial Block Download.
@@ -180,21 +179,18 @@ impl Node {
     }
 
     /// Get the height of the blockchain tip.
-    pub fn get_height(&self) -> Result<u32, NodeError> {
-        let height = self.chain_state.get_height()?;
-        Ok(height)
+    pub fn get_chain_height(&self) -> Result<u32, NodeError> {
+        self.chain_state.get_validation_index().map_err(Into::into)
     }
 
     /// Get the [`Node`]'s validation height.
-    pub fn get_validation_height(&self) -> Result<u32, NodeError> {
-        let height = self.chain_state.get_validation_index()?;
-        Ok(height)
+    pub fn get_node_height(&self) -> Result<u32, NodeError> {
+        self.chain_state.get_validation_index().map_err(Into::into)
     }
 
     /// Get the [`Node`]'s current accumulator, as a [`Stump`].
-    pub fn get_accumulator(&self) -> Result<Stump, NodeError> {
-        let stump = self.chain_state.get_acc();
-        Ok(stump)
+    pub fn get_accumulator(&self) -> Stump {
+        self.chain_state.get_acc()
     }
 
     /// Get the [`BlockHash`] associated with a height.

--- a/src/node.rs
+++ b/src/node.rs
@@ -17,7 +17,6 @@ use floresta_chain::pruned_utreexo::flat_chain_store::FlatChainStore;
 use floresta_chain::pruned_utreexo::BlockchainInterface;
 use floresta_chain::pruned_utreexo::UpdatableChainstate;
 use floresta_chain::BlockConsumer;
-use floresta_chain::BlockchainError;
 use floresta_chain::ChainState;
 use floresta_wire::node::running_ctx::RunningNode;
 use floresta_wire::node::UtreexoNode;
@@ -158,13 +157,8 @@ impl Node {
     pub fn flush(&mut self) -> Result<(), NodeError> {
         self.chain_state.flush().map_err(|e| {
             error!("Error flushing chain state to the file system: {e:?}");
-            match e {
-                BlockchainError::Database(e) => NodeError::Persistence(Arc::new(e)),
-                BlockchainError::Io(e) => NodeError::Io(Arc::new(e)),
-                e => NodeError::Blockchain(Arc::new(e)),
-            }
-        })?;
-        Ok(())
+            NodeError::Flush(e)
+        })
     }
 
     /// A subscriber for validated [`Block`]s.
@@ -342,7 +336,7 @@ impl Node {
             }
             Ok(Err(e)) => {
                 error!("Invalid transaction: {}", e);
-                Err(NodeError::Mempool(e.into()))
+                Err(NodeError::Mempool(e))
             }
             Err(e) => {
                 error!("Failed to broadcast transaction: {}", e);

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -45,20 +45,16 @@ impl BlockConsumer for WalletUpdater {
     ) {
         // Wrap the block in a wallet update.
         let update = WalletUpdate::NewBlock(block.clone(), height);
-        let update_height = height;
 
         // Send the update over the channel.
         match self.sender.send(update) {
             Ok(_) => {
-                debug!(
-                    "Sent block update at height {} over the channel",
-                    update_height
-                );
+                debug!("Sent block update at height {} over the channel", height);
             }
             Err(e) => {
                 error!(
                     "Failed to send block update at height {} over the channel: {}",
-                    update_height, e
+                    height, e
                 );
             }
         }


### PR DESCRIPTION
## Changelog
```
- Bump `floresta-*` to a244e94
- Bump `halfin` to v0.3.0

- Drop `Arc`'s from `BuilderError` and `NodeError` variants
- Rename `Node::get_height` to `Node::get_chain_height`
- Rename `Node::get_validation_height` to `Node::get_node_height`
- Don't return a `Result` from `Node::get_accumulator`
- Update examples