### PR TITLE
Model the `Node` as a Finite-State Machine

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,5 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2026-0098", # blame: bitreq v0.3.4
+    "RUSTSEC-2026-0099", # blame: bitreq v0.3.4
+]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,11 +3,12 @@ name: Integration Tests
 on:
     push:
     pull_request:
-permissions: {}
 env:
     CARGO_TERM_COLOR: always
     RUST_BACKTRACE: 1
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+permissions:
+    contents: read
 
 jobs:
     integration-tests:
@@ -26,6 +27,9 @@ jobs:
 
             - name: Setup build cache
               uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+              with:
+                  cache-on-failure: false
+                  skip-cache-crates: "halfin"
 
             - name: Run ${{ matrix.example }} example
               run: cargo run --release --example ${{ matrix.example }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,11 +3,13 @@ name: Rust CI
 on:
     push:
     pull_request:
-permissions: {}
 env:
     CARGO_TERM_COLOR: always
     RUST_BACKTRACE: 1
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+permissions:
+    contents: read
+
 
 jobs:
     check:
@@ -26,6 +28,9 @@ jobs:
 
             - name: Setup build cache
               uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+              with:
+                  cache-on-failure: false
+                  skip-cache-crates: "halfin"
 
             - name: Setup cargo-rbmt
               uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/setup-rbmt@6560b728ae6a81af9d92713b630ba26772fbd970

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ default = ["logger"]
 logger = ["dep:tracing-appender", "dep:tracing-subscriber"]
 
 [[example]]
+name = "fsm"
+required-features = ["logger"]
+
+[[example]]
 name = "regtest"
 required-features = ["logger"]
 

--- a/examples/fsm.rs
+++ b/examples/fsm.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! An example showcasing the [`Node`]'s [`State`] updating logic.
+
+use core::net::SocketAddr;
+use std::env;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::time::Duration;
+
+use bdk_floresta::builder::Builder;
+use bdk_floresta::builder::NodeConfig;
+use bdk_floresta::fsm::State;
+use bdk_floresta::logger::Logger;
+use bdk_floresta::logger::LOG_FILE;
+use bitcoin::Network;
+use tracing::info;
+use tracing::Level;
+
+const UTREEXOD_CASA21: &str = "189.44.63.101:38333";
+const NETWORK: Network = Network::Signet;
+const DATA_DIR: &str = "./examples/data/fsm/";
+const STATUS_POLL_PERIOD: Duration = Duration::from_secs(5);
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // On display the example's logs
+    env::set_var("RUST_LOG", "fsm=info");
+
+    // Set up the logger
+    let _logger = Logger {
+        log_level: Level::INFO,
+        log_to_stdout: true,
+        log_file: Some(PathBuf::from(DATA_DIR).join("bdk_floresta").join(LOG_FILE)),
+    }
+    .init()?;
+
+    // Configure the node
+    let config = NodeConfig {
+        network: NETWORK,
+        data_directory: PathBuf::from(DATA_DIR).join("bdk_floresta"),
+        fixed_peer: Some(SocketAddr::from_str(UTREEXOD_CASA21)?),
+        ..Default::default()
+    };
+
+    // Instantiate and run the node
+    info!("> Instantiating the node...");
+    let mut node = Builder::new().from_config(config).build()?;
+    info!("> NODE STATE: {}", node.get_state().await);
+
+    info!("> Spawning the node...");
+    node.run().await?;
+    info!("> Node spawned");
+
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+                info!("> /exit");
+                node.shutdown().await?;
+                return Ok(());
+        }
+        result = async {
+            while node.get_state().await != State::Operational {
+                tokio::time::sleep(STATUS_POLL_PERIOD).await;
+                info!("> NODE STATE: {}", node.get_state().await);
+            }
+
+            info!("> NODE STATE: {}", node.get_state().await);
+
+            info!("> /exit");
+            node.shutdown().await?;
+
+            info!("> NODE STATE: {}", node.get_state().await);
+
+            Ok::<_, anyhow::Error>(())
+        } => {
+            result?;
+        }
+    }
+
+    Ok(())
+}

--- a/justfile
+++ b/justfile
@@ -1,9 +1,10 @@
 alias b := build
 alias c := check
 alias d := delete
+alias f := fmt
+alias fsm := example-fsm
 alias reg := example-regtest
 alias sig := example-signet
-alias f := fmt
 alias l := lock
 alias p := pre-push
 
@@ -43,6 +44,11 @@ doc:
 [doc: "Generate and open documentation"]
 doc-open:
     cargo rbmt docs --open
+
+[doc: "Run the `fsm` example"]
+example-fsm:
+    rm -rf examples/data/fsm
+    cargo run --release --example fsm
 
 [doc: "Run the `regtest` example"]
 example-regtest:

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -36,6 +36,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::error::BuilderError;
+use crate::fsm::State;
 #[cfg(feature = "logger")]
 use crate::logger::Logger;
 use crate::updater::WalletUpdater;
@@ -267,6 +268,7 @@ impl Builder {
         };
 
         Ok(Node {
+            state: Arc::new(RwLock::new(State::Inactive)),
             config: self.node_configuration,
             node_inner: Some(node_inner),
             chain_state,
@@ -274,6 +276,7 @@ impl Builder {
             cancellation_token: CancellationToken::new(),
             kill_signal,
             shutdown_task: None,
+            state_update_task: None,
             wallet: wallet_arc,
             update_subscriber: Some(update_rx),
             #[cfg(feature = "logger")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,7 +50,7 @@ impl From<floresta_compact_filters::IterableFilterStoreError> for BuilderError {
     }
 }
 
-/// Errors which might occur when running the [`Node`](crate::node::Node).
+/// Errors that can occur whilst interacting with the [`Node`](crate::node::Node).
 #[derive(Debug, Error)]
 pub enum NodeError {
     /// The [`Node`](crate::node::Node) is already running.

--- a/src/fsm.rs
+++ b/src/fsm.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! # Finite-State Machine Logic for the [`Node`]
+//!
+//! The [`Node`] can be thought of as a [Finite-State Machine].
+//!
+//! This module implements all of the possible [`State`]s that the
+//! [`Node`] can be in, as well as the corresponding next-state logic.
+//!
+//! [Finite-State Machine]: https://en.wikipedia.org/wiki/Finite-state_machine
+
+use core::fmt;
+
+#[allow(unused)]
+use bitcoin::Block;
+#[allow(unused)]
+use floresta_wire::address_man::AddressMan;
+
+use crate::node::Action;
+#[allow(unused)]
+use crate::node::Node;
+
+/// The set of [`State`]s the [`Node`] can possibly be in.
+///
+/// The [`Node`] can be modelled as a Finite State Machine.
+/// As such, we can enumerate the set of possible states it
+/// can be in. This allows restricting certain interactions
+/// with the [`Node`] to when it's in a well-defined set of
+/// [`State`]s. Upstream applications can also use this to
+/// display the [`Node`]'s [`State`] to their users.
+#[derive(Clone, Debug, PartialEq)]
+pub enum State {
+    /// The [`Node`] is not running (S0).
+    Inactive,
+    /// The [`Node`] is active, but not in a well-defined state (S1).
+    Active,
+    // TODO(@luisschwab): how do we figure out when we are in this state?
+    /// The [`Node`] is bootstrapping its [address manager](AddressMan) from DNS seeders (S2).
+    DnsBootstrapping,
+    /// The [`Node`] is synchronizing headers from its peers (S3).
+    HeaderSync(u32),
+    /// The [`Node`] is performing Initial Block Download (S4).
+    InitialBlockDownload((u32, u32)),
+    /// The [`Node`] is downloading Compact Block Filters from its peers (S5).
+    CompactBlockFilterDownload,
+    /// The [`Node`] is performing backfill (S6).
+    Backfill,
+    /// The [`Node`] is fully operational (S7).
+    Operational,
+    /// The [`Node`] is performing an [`Action`] (S8).
+    PerformingAction(Action),
+    /// The [`Node`] is in the process of shutting down (S9).
+    ShuttingDown,
+}
+
+impl fmt::Display for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Active => write!(f, "Active"),
+            Self::DnsBootstrapping => {
+                write!(f, "Bootstrapping the Address Manager from DNS seeders")
+            }
+            Self::HeaderSync(height) => write!(f, "Synchronizing Headers at height={}", height),
+            Self::InitialBlockDownload((node_tip, chain_tip)) => {
+                write!(f, "Performing IBD [{}/{}] ", node_tip, chain_tip)
+            }
+            Self::CompactBlockFilterDownload => write!(f, "Downloading Compact Block Filters"),
+            Self::Backfill => write!(f, "Performing Backfill"),
+            Self::Operational => write!(f, "Operational"),
+            Self::PerformingAction(action) => write!(f, "Performing {}", action),
+            Self::ShuttingDown => write!(f, "Shuting Down"),
+            Self::Inactive => write!(f, "Inactive"),
+        }
+    }
+}
+
+// TODO(@luisschwab): missing
+// - S2 (DNS Bootstrap)
+// - S5 (Compact Filter Download)
+// - S6 (Backfill)
+/// Continuously update the [`Node`]'s [`State`].
+///
+/// Since the [`Node`] is an Finite State Machine,
+/// we compute the next [`State`] from the current
+/// [`State`] and external inputs. See `doc/FSM.md`
+/// for the FSM model and next-state logic.
+pub fn compute_next_state(current_state: State, node_tip: u32, chain_tip: u32) -> State {
+    match current_state {
+        // S1: Active
+        State::Active => {
+            if node_tip == 0 && chain_tip > 0 {
+                State::HeaderSync(chain_tip)
+            } else {
+                State::Active
+            }
+        }
+        // S3: HeaderSync
+        State::HeaderSync(_) => {
+            if node_tip == 0 && chain_tip > 0 {
+                State::HeaderSync(chain_tip)
+            } else {
+                State::InitialBlockDownload((node_tip, chain_tip))
+            }
+        }
+        // S4: InitialBlockDownload
+        State::InitialBlockDownload(_) => {
+            if node_tip != chain_tip {
+                State::InitialBlockDownload((node_tip, chain_tip))
+            } else {
+                State::Operational
+            }
+        }
+        // S7: Operational
+        State::Operational => State::Operational,
+
+        // Skip these variants since their
+        // next-state logic is handled externally:
+        // - S0 (Inactive): handled by the shutdown task
+        // - S8 (PerformingAction): handled by `Node` methods
+        // - S9 (ShuttingDown): handled by the shutdown task
+        //
+        // Skip these variants since their
+        // next state logic still needs other TODOs:
+        // - S2 (DnsBootstrapping)
+        // - S5 (CompactBlockFilterDownload)
+        // - S6 (Backfill)
+        s @ State::PerformingAction(_)
+        | s @ State::ShuttingDown
+        | s @ State::Inactive
+        | s @ State::CompactBlockFilterDownload
+        | s @ State::DnsBootstrapping
+        | s @ State::Backfill => s,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub use floresta_wire::UtreexoNodeConfig;
 
 pub mod builder;
 pub mod error;
+pub mod fsm;
 #[cfg(feature = "logger")]
 pub mod logger;
 pub mod node;

--- a/src/node.rs
+++ b/src/node.rs
@@ -4,7 +4,8 @@
 //!
 //! This module holds all the logic needed to interact with the [`Node`].
 
-use std::net::SocketAddr;
+use core::fmt;
+use core::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -18,6 +19,8 @@ use floresta_chain::pruned_utreexo::BlockchainInterface;
 use floresta_chain::pruned_utreexo::UpdatableChainstate;
 use floresta_chain::BlockConsumer;
 use floresta_chain::ChainState;
+#[allow(unused)]
+use floresta_wire::address_man::AddressMan;
 use floresta_wire::node::running_ctx::RunningNode;
 use floresta_wire::node::UtreexoNode;
 use floresta_wire::node_interface::NodeInterface;
@@ -37,6 +40,8 @@ use tracing_appender::non_blocking::WorkerGuard;
 
 use crate::builder::NodeConfig;
 use crate::error::NodeError;
+use crate::fsm::compute_next_state;
+use crate::fsm::State;
 use crate::updater::WalletUpdate;
 
 /// The period between polls for the `status_update_task`, in milliseconds.
@@ -83,86 +88,74 @@ impl fmt::Display for Action {
     }
 }
 
-/// Type alias for the [`Node`]'s inner [`UtreexoNode`].
+/// An alias to the [`Node`]'s inner: [`UtreexoNode`].
 type NodeInner = UtreexoNode<Arc<ChainState<FlatChainStore>>, RunningNode>;
 
-/// The embedded and fully-validating Compact State [`Node`].
+/// The [`Node`].
+///
+/// It groups all of the required pieces for the [`Node`] to function.
 pub struct Node {
-    /// The [`Node`]'s configuration settings.
-    pub(crate) config: NodeConfig,
+    /// The [`Node`]'s current [`State`].
+    pub state: Arc<RwLock<State>>,
+
     /// The inner, underlying [`UtreexoNode`].
     pub(crate) node_inner: Option<NodeInner>,
+
+    /// The [`Node`]'s configuration settings.
+    pub(crate) config: NodeConfig,
+
     /// The [`Node`]'s blockchain state.
     pub(crate) chain_state: Arc<ChainState<FlatChainStore>>,
+
     /// A handle used to interact with the [`UtreexoNode`].
     pub(crate) node_handle: NodeInterface,
+
     /// A cancellation token used to signal shutdown to all tasks,
     /// Triggered via `SIGINT` or [`Node::shutdown()`].
     pub(crate) cancellation_token: CancellationToken,
+
     /// A kill signal shared with the inner [`UtreexoNode`],
     /// set to `true` to instruct it to stop processing and exit.
     pub(crate) kill_signal: Arc<RwLock<bool>>,
-    /// Handle to the background task that drives graceful shutdown:
-    /// sets the kill signal, waits for the inner node to stop, and flushes
-    /// the chain state to disk. Awaited by [`Node::shutdown()`] and [`Node::cancelled()`].
+
+    /// A handle to the shutdown task.
+    ///
+    /// It sets the kill signal, waits for the [`NodeInner`] to
+    /// stop, and flushes the [`ChainState`] to the file system.
+    /// Awaited by [`Node::shutdown()`] and [`Node::cancelled()`].
     pub(crate) shutdown_task: Option<JoinHandle<()>>,
+
+    /// A handle to the status update task.
+    ///
+    /// This task will update the [`Node`]'s [`State`]
+    /// by polling the [`ChainState`] and interpreting
+    /// the values returned into a [`State`].
+    pub(crate) state_update_task: Option<JoinHandle<()>>,
+
     /// A [`Wallet`] that will receive updates from the [`Node`].
     pub wallet: Option<Arc<RwLock<Wallet>>>,
+
     /// Receiver for [`WalletUpdate`]s that come from
     /// the [`Node`] and should be applied to the [`Wallet`].
     pub update_subscriber: Option<UnboundedReceiver<WalletUpdate>>,
+
     /// A guard that ensures the logger remains active for the [`Node`]'s lifetime.
     #[cfg(feature = "logger")]
     pub(crate) _log_guard: Option<WorkerGuard>,
 }
 
 impl Node {
-    /// Spawn and run the [`Node`].
-    ///
-    /// This method will spawn a task for the inner [`UtreexoNode`] and the shutdown handler task.
-    pub async fn run(&mut self) -> Result<(), NodeError> {
-        // Take the inner node to make sure `Node::run()` can only be called once.
-        let inner_node = self.node_inner.take().ok_or(NodeError::AlreadyRunning)?;
-
-        // Create a channel to carry shutdown notifications.
-        let (node_stopped_tx, node_stopped_rx) = oneshot::channel::<()>();
-        // Spawn a task which will run the node.
-        let node_task: JoinHandle<()> = tokio::task::spawn(inner_node.run(node_stopped_tx));
-
-        let cancellation_token = self.cancellation_token.clone();
-        let kill_signal = self.kill_signal.clone();
-        let chain_state = self.chain_state.clone();
-
-        // Spawn a task that listens for SIGINT or `Node::shutdown` and waits for tasks to complete
-        let shutdown_task = tokio::task::spawn(async move {
-            tokio::select! {
-                _ = tokio::signal::ctrl_c() => { info!("Shutting down"); }
-                _ = cancellation_token.cancelled() => { info!("Shutting down"); }
-            }
-            *kill_signal.write().await = true;
-
-            let timeout = Duration::from_secs(SHUTDOWN_TIMEOUT);
-            Self::await_with_timeout(node_stopped_rx, timeout).await;
-            Self::join_with_timeout(node_task, timeout).await;
-
-            if let Err(e) = chain_state.flush() {
-                error!("Error flushing chain state to the file system: {e:?}");
-            }
-
-            cancellation_token.cancel();
-            info!("Shutdown complete");
-        });
-
-        self.shutdown_task = Some(shutdown_task);
-        Ok(())
-    }
+    // ----> INTERNAL METHODS
 
     /// Await the [`oneshot::Receiver`] for a set timeout.
     async fn await_with_timeout(rx: oneshot::Receiver<()>, timeout: Duration) {
         match tokio::time::timeout(timeout, rx).await {
             Ok(Ok(())) => {}
             Ok(Err(_)) => warn!("Shutdown channel closed without sending"),
-            Err(_) => error!("Shutdown channel timed out after {SHUTDOWN_TIMEOUT} seconds"),
+            Err(_) => error!(
+                "Shutdown channel timed out after {} seconds",
+                SHUTDOWN_TIMEOUT.as_secs()
+            ),
         }
     }
 
@@ -170,18 +163,12 @@ impl Node {
     async fn join_with_timeout(task: JoinHandle<()>, timeout: Duration) {
         match tokio::time::timeout(timeout, task).await {
             Ok(Ok(_)) => {}
-            Ok(Err(e)) => error!("Node task failed during shutdown: {e:?}"),
-            Err(_) => warn!("Node task join timed out after {SHUTDOWN_TIMEOUT} seconds"),
+            Ok(Err(e)) => error!("Node task failed during shutdown: {:?}", e),
+            Err(_) => warn!(
+                "Node task join timed out after {} seconds",
+                SHUTDOWN_TIMEOUT.as_secs()
+            ),
         }
-    }
-
-    /// Programatically request the [node](`Node`) to shutdown.
-    pub async fn shutdown(&mut self) -> Result<(), NodeError> {
-        self.cancellation_token.cancel();
-        if let Some(task) = self.shutdown_task.take() {
-            let _ = task.await;
-        }
-        Ok(())
     }
 
     /// Suspend the caller until the [`Node`] has completed shutdown.
@@ -194,6 +181,104 @@ impl Node {
         }
     }
 
+    // ----> CONTROL METHODS
+
+    /// Spawn and run the [`Node`].
+    ///
+    /// This method will spawn two tasks:
+    /// - A task that runs the inner [`UtreexoNode`].
+    /// - A task for the shutdown handler, which reacts to a [`Node::shutdown`] call or a `SIGINT`
+    ///   signal, and perfoms the graceful shutdown routine.
+    pub async fn run(&mut self) -> Result<(), NodeError> {
+        // `take()` the inner node to make sure `Node::run()` can only be called once
+        let inner_node = self.node_inner.take().ok_or(NodeError::AlreadyRunning)?;
+
+        // Set the node's state to `State::Active`
+        *self.state.write().await = State::Active;
+
+        // Create a channel to carry shutdown notifications
+        let (node_stopped_tx, node_stopped_rx) = oneshot::channel::<()>();
+
+        // Spawn a task that will run the node
+        let node_task: JoinHandle<()> = tokio::task::spawn(inner_node.run(node_stopped_tx));
+
+        // Spawn a task that will update the node's state
+        let state = self.state.clone();
+        let cancellation_token = self.cancellation_token.clone();
+        let kill_signal = self.kill_signal.clone();
+        let chain_state = self.chain_state.clone();
+
+        let state_update_task = tokio::task::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = cancellation_token.cancelled() => break,
+                    // Sleep for `STATUS_UPDATE_POLL_PERIOD` between polls
+                    _ = tokio::time::sleep(STATUS_UPDATE_POLL_PERIOD) => {
+                        let node_tip = chain_state.get_validation_index();
+                        let Ok(node_tip) = node_tip else {
+                            error!("Failed to compute FSM's next state (failed to get node tip): {}", node_tip.unwrap_err());
+                            continue
+                        };
+
+                        let chain_tip = chain_state.get_best_block();
+                        let Ok((chain_tip, _)) = chain_tip else {
+                            error!("Failed to compute FSM's next state (failed to get chain tip): {}", chain_tip.unwrap_err());
+                            continue
+                        };
+                        let current_state = state.read().await.clone();
+
+                        if !matches!(current_state, State::PerformingAction(_) | State::ShuttingDown) {
+                            *state.write().await = compute_next_state(current_state, node_tip, chain_tip);
+                        }
+                    }
+                }
+            }
+        });
+        self.state_update_task = Some(state_update_task);
+
+        // Spawn a task that listens for SIGINT or `Node::shutdown` and waits for tasks to complete
+        let state = self.state.clone();
+        let cancellation_token = self.cancellation_token.clone();
+        let chain_state = self.chain_state.clone();
+
+        let shutdown_task = tokio::task::spawn(async move {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => { info!("Shutting down"); }
+                _ = cancellation_token.cancelled() => { info!("Shutting down"); }
+            }
+            // Set the node's state to `State::ShuttingDown`
+            *state.write().await = State::ShuttingDown;
+
+            *kill_signal.write().await = true;
+
+            Self::await_with_timeout(node_stopped_rx, SHUTDOWN_TIMEOUT).await;
+            Self::join_with_timeout(node_task, SHUTDOWN_TIMEOUT).await;
+
+            if let Err(e) = chain_state.flush() {
+                error!("Error flushing chain state to the file system: {e:?}");
+            }
+
+            cancellation_token.cancel();
+
+            // Set the node's state to `State::Inactive`
+            *state.write().await = State::Inactive;
+
+            info!("Shutdown complete");
+        });
+        self.shutdown_task = Some(shutdown_task);
+
+        Ok(())
+    }
+
+    /// Programatically request the [node](`Node`) to shutdown.
+    pub async fn shutdown(&mut self) -> Result<(), NodeError> {
+        self.cancellation_token.cancel();
+        if let Some(task) = self.shutdown_task.take() {
+            let _ = task.await;
+        }
+        Ok(())
+    }
+
     /// Flush the [`Node`]'s [chainstate](ChainState) to the file system.
     pub fn flush(&mut self) -> Result<(), NodeError> {
         self.chain_state.flush().map_err(|e| {
@@ -202,11 +287,11 @@ impl Node {
         })
     }
 
-    /// A subscriber for validated [`Block`]s.
-    ///
-    /// Implements the [`BlockConsumer`] trait from [`floresta-chain`](floresta_chain).
-    pub fn block_subscriber<T: BlockConsumer + 'static>(&self, block_consumer: Arc<T>) {
-        self.chain_state.subscribe(block_consumer);
+    // ----> LOCAL METHODS
+
+    /// Get the [`Node`]'s current [`State`].
+    pub async fn get_state(&self) -> State {
+        self.state.read().await.clone()
     }
 
     /// Get the [`Node`]'s current [`NodeConfig`].
@@ -241,6 +326,13 @@ impl Node {
         Ok(hash)
     }
 
+    /// A subscriber for validated [`Block`]s.
+    ///
+    /// Implements the [`BlockConsumer`] trait from [`floresta-chain`](floresta_chain).
+    pub fn block_subscriber<T: BlockConsumer + 'static>(&self, block_consumer: Arc<T>) {
+        self.chain_state.subscribe(block_consumer);
+    }
+
     /// Get information about peers the [`Node`] is currently connected to.
     pub async fn get_peer_info(&self) -> Result<Vec<PeerInfo>, NodeError> {
         match self.node_handle.get_peer_info().await {
@@ -255,88 +347,159 @@ impl Node {
         }
     }
 
-    /// Manually connect to a specific peer, given a [`SocketAddr`].
+    // ----> NETWORK METHODS
+
+    /// Fetch a [`Block`] given its [`BlockHash`].
     ///
-    /// Returns a `bool` indicating whether the connection was successfully established.
+    /// Since [`floresta-chain`](floresta_chain) does not persist any
+    /// [`Block`]s, these must be requested over the wire from a peer.
+    pub async fn fetch_block(&self, hash: BlockHash) -> Result<Option<Block>, NodeError> {
+        let last_state = self.state.read().await.clone();
+        *self.state.write().await =
+            State::PerformingAction(Action::FetchingBlock(hash.to_string()));
+
+        let block = self.node_handle.get_block(hash).await?;
+
+        *self.state.write().await = last_state;
+
+        Ok(block)
+    }
+
+    /// Broadcast a [`Transaction`] to the [`Node`]'s peers.
+    ///
+    /// Returns the [`Txid`], if the broadcast was successful.
+    pub async fn broadcast_tx(&self, tx: Transaction) -> Result<Txid, NodeError> {
+        let txid = tx.compute_txid();
+
+        let last_state = self.state.read().await.clone();
+        *self.state.write().await =
+            State::PerformingAction(Action::BroadcastingTransaction(txid.to_string()));
+
+        let result = match self.node_handle.broadcast_transaction(tx).await {
+            Ok(Ok(txid)) => {
+                info!("Successfully broadcast transaction with txid={}", txid);
+                Ok(txid)
+            }
+            Ok(Err(e)) => {
+                error!(
+                    "Failed to broadcast an invalid transaction with txid={}: {}",
+                    txid, e
+                );
+                Err(NodeError::Mempool(e))
+            }
+            Err(e) => {
+                error!("Failed to broadcast transaction with txid={}: {}", txid, e);
+                Err(NodeError::Receiver(e))
+            }
+        };
+        *self.state.write().await = last_state;
+
+        result
+    }
+
+    /// Manually connect to a specific peer, given its [`SocketAddr`].
+    ///
+    /// Returns a `bool` indicating whether the connection was successful.
     pub async fn add_peer(&self, socket: &SocketAddr) -> Result<bool, NodeError> {
-        match self
+        let last_state = self.state.read().await.clone();
+        *self.state.write().await =
+            State::PerformingAction(Action::ConnectingToPeer(socket.to_string()));
+
+        let result = match self
             .node_handle
             .add_peer(socket.ip(), socket.port(), self.config.allow_p2pv1_fallback)
             .await
         {
             Ok(true) => {
-                debug!("Manual connection established with peer {socket:#?} successfully");
+                debug!("Connected to peer={}", socket);
                 Ok(true)
             }
             Ok(false) => {
-                warn!("Failed to establish manual connection with peer {socket:#?}");
+                warn!("Failed to connect to peer={}", socket);
                 Ok(false)
             }
             Err(e) => {
-                error!("Network error while attempting to establish manual connection with peer {socket:#?}: {e}");
+                error!("Error whilst connecting to peer={}: {}", socket, e);
                 Err(NodeError::Receiver(e))
             }
-        }
+        };
+        *self.state.write().await = last_state;
+
+        result
     }
 
-    /// Disconnect from a specific peer, given its [`SocketAddr`].
+    /// Disconnect from a peer, given its [`SocketAddr`].
     ///
-    /// Returns a `bool` indicating whether the peer was successfully disconnected from.
+    /// Returns a `bool` indicating whether the [`Node`] successfully disconnected from the peer.
     pub async fn disconnect_peer(&self, socket: &SocketAddr) -> Result<bool, NodeError> {
-        match self
+        let last_state = self.state.read().await.clone();
+        *self.state.write().await =
+            State::PerformingAction(Action::DisconnectingFromPeer(socket.to_string()));
+
+        let result = match self
             .node_handle
             .disconnect_peer(socket.ip(), socket.port())
             .await
         {
             Ok(true) => {
-                debug!("Disconnected from peer {socket:#?}");
+                debug!("Disconnected from peer={socket}");
                 Ok(true)
             }
             Ok(false) => {
-                error!("Failed to disconnect from peer {socket:#?}");
+                error!("Failed to disconnect from peer={socket}");
                 Ok(false)
             }
             Err(e) => {
-                error!("Failed disconnect from peer {socket:#?}: {e}");
+                error!("Error whilst disconnecting from peer={socket}: {e}");
                 Err(NodeError::Receiver(e))
             }
-        }
+        };
+        *self.state.write().await = last_state;
+
+        result
     }
 
-    /// Remove a specific peer's address from the
-    /// [`AddressMan`](floresta_wire::address_man::AddressMan), given its [`SocketAddr`].
+    /// Remove a specific peer's address from the [`Node`]'s
+    /// (address manager)[AddressMan], given its [`SocketAddr`].
     ///
     /// Returns a `bool` indicating whether the address was successfully removed.
     pub async fn remove_peer(&self, socket: &SocketAddr) -> Result<bool, NodeError> {
-        match self
+        let last_state = self.state.read().await.clone();
+        *self.state.write().await =
+            State::PerformingAction(Action::RemovingPeer(socket.to_string()));
+
+        let result = match self
             .node_handle
             .remove_peer(socket.ip(), socket.port())
             .await
         {
             Ok(true) => {
-                debug!("Removed address {} from the address manager", socket);
+                debug!("Removed peer={} from the address manager", socket);
                 Ok(true)
             }
             Ok(false) => {
-                error!(
-                    "Failed to remove address {} from the address manager",
-                    socket
-                );
+                error!("Failed to remove peer={} from the address manager", socket);
                 Ok(false)
             }
             Err(e) => {
                 error!(
-                    "Failed to remove address {} from the address manager: {}",
+                    "Failed to remove peer={} from the address manager: {}",
                     socket, e
                 );
                 Err(NodeError::Receiver(e))
             }
-        }
+        };
+        *self.state.write().await = last_state;
+
+        result
     }
 
-    /// Ping all of the [`Node`]'s peers.
+    /// Send a `ping` to all of the [`Node`]'s peers.
     pub async fn ping(&self) -> Result<bool, NodeError> {
-        match self.node_handle.ping().await {
+        let last_state = self.state.read().await.clone();
+        *self.state.write().await = State::PerformingAction(Action::Pinging);
+
+        let result = match self.node_handle.ping().await {
             Ok(true) => {
                 debug!("Sent a ping to all peers");
                 Ok(true)
@@ -346,39 +509,12 @@ impl Node {
                 Ok(false)
             }
             Err(e) => {
-                error!("Error whilst receiving ping response: {}", e);
+                error!("Error whilst receiving ping response: {e}");
                 Err(NodeError::Receiver(e))
             }
-        }
-    }
+        };
+        *self.state.write().await = last_state;
 
-    /// Fetch a [`Block`] given its [`BlockHash`].
-    ///
-    /// Since [`floresta-chain`](floresta_chain) does not persist any
-    /// [`Block`]s, these must be requested over the wire from a peer.
-    pub async fn fetch_block(&self, blockhash: BlockHash) -> Result<Option<Block>, NodeError> {
-        let block = self.node_handle.get_block(blockhash).await?;
-
-        Ok(block)
-    }
-
-    /// Broadcast a [`Transaction`] to the [`Node`]'s peers.
-    ///
-    /// Returns the [`Txid`], if the broadcast was successful.
-    pub async fn broadcast_tx(&self, tx: Transaction) -> Result<Txid, NodeError> {
-        match self.node_handle.broadcast_transaction(tx).await {
-            Ok(Ok(txid)) => {
-                info!("Broadcast transaction {}", txid);
-                Ok(txid)
-            }
-            Ok(Err(e)) => {
-                error!("Invalid transaction: {}", e);
-                Err(NodeError::Mempool(e))
-            }
-            Err(e) => {
-                error!("Failed to broadcast transaction: {}", e);
-                Err(NodeError::Receiver(e))
-            }
-        }
+        result
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -39,8 +39,49 @@ use crate::builder::NodeConfig;
 use crate::error::NodeError;
 use crate::updater::WalletUpdate;
 
-/// Timeout for the [`Node`]'s shutdown task, in seconds.
-const SHUTDOWN_TIMEOUT: u64 = 15;
+/// The period between polls for the `status_update_task`, in milliseconds.
+const STATUS_UPDATE_POLL_PERIOD: Duration = Duration::from_millis(500);
+
+/// The timeout for the [`Node`]'s shutdown task, in seconds.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The set of [`Action`]s the [`Node`] can
+/// possibly be performing at any given instant.
+///
+/// These [`Action`]s are triggered when a user calls
+/// [`Node`] methods (e.g. scaning the blockchain with
+/// Compact Block Filters).
+#[derive(Clone, Debug, PartialEq)]
+pub enum Action {
+    /// The [`Node`] is connecting to a peer.
+    ConnectingToPeer(String),
+    /// The [`Node`] is disconnecting from a peer.
+    DisconnectingFromPeer(String),
+    /// The [`Node`] is removing a peer from its [address manager](AddressMan).
+    RemovingPeer(String),
+    /// The [`Node`] is pinging all of its peers.
+    Pinging,
+    /// The [`Node`] is fetching a [`Block`] from a peers.
+    FetchingBlock(String),
+    /// The [`Node`] is scanning the blockchain with Compact Block Filters.
+    CompactFilterScan((u32, u32)),
+    /// The [`Node`] is broadcasting a [`Transaction`].
+    BroadcastingTransaction(String),
+}
+
+impl fmt::Display for Action {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ConnectingToPeer(socket) => write!(f, "Connecting to peer={}", socket),
+            Self::DisconnectingFromPeer(socket) => write!(f, "Disconnecting from peer={}", socket),
+            Self::RemovingPeer(socket) => write!(f, "Removing peer={}", socket),
+            Self::Pinging => write!(f, "Pinging all peers"),
+            Self::FetchingBlock(hash) => write!(f, "Fetching block with hash={}", hash),
+            Self::CompactFilterScan((start_height, end_height)) => write!(f, "Scanning the blockchain with Compact Block Filters from start_height={} up to end_height={}", start_height, end_height),
+            Self::BroadcastingTransaction(txid) => write!(f, "Broadcasting transaction with txid={}", txid),
+        }
+    }
+}
 
 /// Type alias for the [`Node`]'s inner [`UtreexoNode`].
 type NodeInner = UtreexoNode<Arc<ChainState<FlatChainStore>>, RunningNode>;


### PR DESCRIPTION
This PR models the `Node` into a Finite-State Machine and exposes that via `Node::get_state`. The `State` describes in which stage of execution the `Node` is in.

## Changelog
```
- Add an ` State` enum with the `Node`'s possible states
- Add next-state logic via `compute_next_state`
- Update `Node` and it's methods so that it does `State` transitions as it runs
- Add example showcasing this capability (`examples/fsm.rs`)
- Update `Cargo.toml` and `justfile`
- Give `rust.yml` and `integration.yml` read permissions