### PR TITLE
Add Linux cross-compilation targets

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -1,4 +1,4 @@
-name: Cross-Testing
+name: Cross
 
 on:
     push:
@@ -13,8 +13,9 @@ env:
     RUST_BACKTRACE: 1
 
 jobs:
-    cross:
-        name: ${{ matrix.os }} + ${{ matrix.arch }}
+    # Build and Test natively
+    cross-native:
+        name: "${{ matrix.target }} [native]"
         runs-on: ${{ matrix.runner }}
         strategy:
             fail-fast: false
@@ -22,23 +23,15 @@ jobs:
                 include:
                     - runner: macos-latest
                       target: aarch64-apple-darwin
-                      os: MacOS
-                      arch: aarch64 (Apple Silicon)
 
                     - runner: ubuntu-24.04-arm
                       target: aarch64-unknown-linux-gnu
-                      os: Linux
-                      arch: aarch64
 
-                    - runner: ubuntu-latest
+                    - runner: ubuntu-24.04
                       target: x86_64-unknown-linux-gnu
-                      os: Linux
-                      arch: x86_64
 
                     - runner: windows-2025-vs2026
                       target: x86_64-pc-windows-msvc
-                      os: Windows
-                      arch: x86_64
 
         steps:
             - name: Checkout Repository
@@ -58,3 +51,128 @@ jobs:
             - name: Run Tests
               shell: bash
               run: cargo rbmt test
+
+    # Build and Test foreign achitectures on an x86_64 Linux runner using QEMU
+    cross-linux:
+        name: "${{ matrix.target }} [qemu]"
+        runs-on: ubuntu-24.04
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - target: riscv64gc-unknown-linux-gnu
+                      emulator: qemu-riscv64-static
+                      toolchain-prefix: riscv64-linux-gnu
+                      system-processor: riscv64
+                      sysroot: /usr/riscv64-linux-gnu
+
+                    - target: riscv64a23-unknown-linux-gnu
+                      emulator: qemu-riscv64-static
+                      toolchain-prefix: riscv64-linux-gnu
+                      system-processor: riscv64
+                      sysroot: /usr/riscv64-linux-gnu
+
+                    - target: s390x-unknown-linux-gnu
+                      emulator: qemu-s390x-static
+                      toolchain-prefix: s390x-linux-gnu
+                      system-processor: s390x
+                      sysroot: /usr/s390x-linux-gnu
+
+                    - target: powerpc64le-unknown-linux-gnu
+                      emulator: qemu-ppc64le-static
+                      toolchain-prefix: powerpc64le-linux-gnu
+                      system-processor: ppc64le
+                      sysroot: /usr/powerpc64le-linux-gnu
+
+                    - target: powerpc64-unknown-linux-gnu
+                      emulator: qemu-ppc64-static
+                      toolchain-prefix: powerpc64-linux-gnu
+                      system-processor: ppc64
+                      sysroot: /usr/powerpc64-linux-gnu
+
+                    - target: sparc64-unknown-linux-gnu
+                      emulator: qemu-sparc64-static
+                      toolchain-prefix: sparc64-linux-gnu
+                      system-processor: sparc64
+                      sysroot: /usr/sparc64-linux-gnu
+
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  persist-credentials: false
+
+            - name: Setup Rust Cache
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+              with:
+                  key: ${{ matrix.target }}
+
+            - name: Setup cargo-rbmt
+              uses: $/.github/actions/setup-rbmt
+
+            - name: Setup libbitcoinkernel
+              uses: $/.github/actions/setup-libbitcoinkernel
+
+            - name: Install QEMU and Foreign C/C++ Toolchain
+              shell: bash
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y \
+                      qemu-user-static \
+                      "gcc-${{ matrix.toolchain-prefix }}" \
+                      "g++-${{ matrix.toolchain-prefix }}"
+
+            - name: Resolve Stable Toolchain Version
+              shell: bash
+              run: echo "STABLE_TOOLCHAIN=$(cargo rbmt toolchains --stable)" >> "$GITHUB_ENV"
+
+            - name: "Install Rust Target: ${{ matrix.target }}"
+              shell: bash
+              run: rustup target add --toolchain "$STABLE_TOOLCHAIN" "${{ matrix.target }}"
+
+            - name: Configure the CMake Toolchain
+              shell: bash
+              run: |
+                  # Locate the host Boost package used for Bitcoin Core's header-only dependency
+                  toolchain="$RUNNER_TEMP/linux-cross.cmake"
+                  boost_configs=(/usr/lib/"$(gcc -print-multiarch)"/cmake/Boost-*/BoostConfig.cmake)
+                  test -f "${boost_configs[0]}"
+                  boost_dir="${boost_configs[0]%/*}"
+
+                  # TODO(@luisschwab): remove the PIC override on the next rust-bitcoinkernel release
+                  # Configure CMake for the foreign target while using the host's Boost headers
+                  printf '%s\n' \
+                      'set(CMAKE_SYSTEM_NAME Linux)' \
+                      'set(CMAKE_SYSTEM_PROCESSOR ${{ matrix.system-processor }})' \
+                      'set(CMAKE_C_COMPILER ${{ matrix.toolchain-prefix }}-gcc)' \
+                      'set(CMAKE_CXX_COMPILER ${{ matrix.toolchain-prefix }}-g++)' \
+                      'set(CMAKE_AR ${{ matrix.toolchain-prefix }}-ar)' \
+                      'set(CMAKE_RANLIB ${{ matrix.toolchain-prefix }}-ranlib)' \
+                      'set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)' \
+                      'set(CMAKE_POSITION_INDEPENDENT_CODE ON)' \
+                      'set(CMAKE_FIND_ROOT_PATH ${{ matrix.sysroot }})' \
+                      'set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)' \
+                      'set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)' \
+                      'set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)' \
+                      'set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)' \
+                      "set(Boost_DIR \"$boost_dir\")" \
+                      > "$toolchain"
+
+                  echo "CMAKE_TOOLCHAIN_FILE=$toolchain" >> "$GITHUB_ENV"
+
+            - name: Run Tests
+              shell: bash
+              run: |
+                  # Derive the variable-name forms expected by `cc-rs` and `cargo` from the target triple
+                  target_env="$(printf '%s' '${{ matrix.target }}' | tr '-' '_')"
+                  cargo_target_env="$(printf '%s' '${{ matrix.target }}' | tr 'a-z-' 'A-Z_')"
+
+                  # Keep the cross compiler scoped to target code so host build scripts remain native
+                  export "AR_${target_env}=${{ matrix.toolchain-prefix }}-ar"
+                  export "CC_${target_env}=${{ matrix.toolchain-prefix }}-gcc"
+                  export "CXX_${target_env}=${{ matrix.toolchain-prefix }}-g++"
+                  export "RANLIB_${target_env}=${{ matrix.toolchain-prefix }}-ranlib"
+                  export "CARGO_TARGET_${cargo_target_env}_LINKER=${{ matrix.toolchain-prefix }}-gcc"
+                  export "CARGO_TARGET_${cargo_target_env}_RUNNER=${{ matrix.emulator }} -L ${{ matrix.sysroot }}"
+
+                  cargo rbmt run -- test --target "${{ matrix.target }}" --tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -111,7 +111,7 @@ jobs:
               run: cargo rbmt test --toolchain ${{ matrix.toolchain }} --lockfile ${{ matrix.lockfile }}
 
     llvm-cov:
-        name: LLVM Cov
+        name: Coverage
         runs-on: ubuntu-latest
 
         steps:


### PR DESCRIPTION
Extends `cross.yml` with more Linux targets:
* `riscv64gc-unknown-linux-gnu`
* `riscv64a23-unknown-linux-gnu`
* `s390x-unknown-linux-gnu`
* `powerpc64le-unknown-linux-gnu`
* `powerpc64-unknown-linux-gnu`
* `sparc64-unknown-linux-gnu`

These are cross-compiled with `cargo` and emulated using QEMU on an x86_64 Linux runner.

Floresta still doesn't support 32 bit and `no-std` targets, so these are omitted for the time being.